### PR TITLE
Support persistent Xconfig file

### DIFF
--- a/LoopConfigOverride.xcconfig
+++ b/LoopConfigOverride.xcconfig
@@ -1,3 +1,4 @@
+#include? "../../LoopConfigOverride.xcconfig"
 
 // Override this if you don't want the default com.${DEVELOPMENT_TEAM}.loopkit that loop uses
 // MAIN_APP_BUNDLE_IDENTIFIER = com.myname.loop


### PR DESCRIPTION
It can be cumbersome to change your team ID for every branch you check out to test. This change will allow you to drop an xcconfig file in the directory above your LoopWorkspace clone. I was hoping to do this in a file in the ~/ or ~/Desktop but I can't see how to generically access the user's home directory ($HOME and ~ not supported).