### PR TITLE
Support persistent Xconfig file

### DIFF
--- a/LoopConfigOverride.xcconfig
+++ b/LoopConfigOverride.xcconfig
@@ -1,3 +1,4 @@
+#include? "../../LoopDeveloperOverride.xcconfig"
 #include? "../../LoopConfigOverride.xcconfig"
 
 // Override this if you don't want the default com.${DEVELOPMENT_TEAM}.loopkit that loop uses
@@ -10,4 +11,4 @@ MAIN_APP_DISPLAY_NAME = Loop
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) ALLOW_SIMULATORS_ENABLED //ALLOW_DEBUG_FEATURES_ENABLED
 
 // Put your team id here for signing
-//LOOP_DEVELOPMENT_TEAM = UY678SP37Q
+//LOOP_DEVELOPMENT_TEAM = YOUR_ID_HERE


### PR DESCRIPTION
Allow for a persistent file 
* to support the standard builder who uses the script and just wants to have the Apple Developer ID easily available
* to support developers who may have additional overrides that are persistent and may vary across environments

Remove specify developer ID from the repo