### PR TITLE
g7 experimental

### DIFF
--- a/Loop.xcworkspace/xcshareddata/xcschemes/Loop (Workspace).xcscheme
+++ b/Loop.xcworkspace/xcshareddata/xcschemes/Loop (Workspace).xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
@@ -283,6 +283,20 @@
                BlueprintIdentifier = "B4D40D2D23A3E91800D7ECB5"
                BuildableName = "CGMBLEKitG6Plugin.loopplugin"
                BlueprintName = "CGMBLEKitG6Plugin"
+               ReferencedContainer = "container:CGMBLEKit/CGMBLEKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C1BA045D28DF89FD00CD6BA4"
+               BuildableName = "CGMBLEKitG7Plugin.loopplugin"
+               BlueprintName = "CGMBLEKitG7Plugin"
                ReferencedContainer = "container:CGMBLEKit/CGMBLEKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>


### PR DESCRIPTION
This is an experimental version of Dexcom G7 integration for Loop. You should be able to add the CGMManager, and it will auto-connect to your G7, as long as you have the native G7 app running and paired to a sensor. To switch sensors (like when pairing a new one), for now you will need to remove the cgm manager, and re-add it, which is just a few clicks. It will be more reliable if you do this after you pair your new sensor in the G7 app. Eventually it should auto-follow, but that's not done yet.

Since this is fresh reverse-engineering of a new protocol, it's still possible that dangerous errors in decoding are still present. Generally the data matches what is shown in the Dexcom app, and I believe calibrations are detected properly, but there are probably error states that aren't handled correctly, and those could be parsed as incorrect BG readings, leading Loop to deliver incorrect/unsafe dosing. Because of that, I'd recommend that testing be done only with the simulator pump, and not a real insulin delivery device.

The UI is very rudimentary, and will change quite a bit, so no need for feedback on that yet.