### PR TITLE
Validate repository secrets

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -3,7 +3,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  secrets:
+    uses: ./.github/workflows/validate_secrets.yml
+    secrets: inherit
+    
   identifiers:
+    needs: secrets
     runs-on: macos-12
     steps:
       # Uncomment to manually select latest Xcode if needed

--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -1,4 +1,5 @@
-name: Add Identifiers
+name: 2. Add Identifiers
+run-name: Add Identifiers
 on:
   workflow_dispatch:
 

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -1,4 +1,5 @@
-name: Build Loop
+name: 4. Build Loop
+run-name: Build Loop
 on:
   workflow_dispatch:
 

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -3,7 +3,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  secrets:
+    uses: ./.github/workflows/validate_secrets.yml
+    secrets: inherit
+    
   build:
+    needs: secrets
     runs-on: macos-12
     steps:
       # Uncomment to manually select latest Xcode if needed

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -3,7 +3,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  secrets:
+    uses: ./.github/workflows/validate_secrets.yml
+    secrets: inherit
+    
   certificates:
+    needs: secrets
     runs-on: macos-12
     steps:
       # Uncomment to manually select latest Xcode if needed

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -1,4 +1,5 @@
-name: Create Certificates
+name: 3. Create Certificates
+run-name: Create Certificates
 on:
   workflow_dispatch:
 

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -1,4 +1,5 @@
-name: Validate Secrets
+name: 1. Validate Secrets
+run-name: Validate Secrets
 on: [workflow_call, workflow_dispatch]
   
 jobs:

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -1,0 +1,69 @@
+name: Validate Secrets
+on: [workflow_call, workflow_dispatch]
+  
+jobs:
+  validate:
+    runs-on: macos-12
+    steps:
+      # Checks-out the repo
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      
+      # Validates the repo secrets
+      - name: Validate Secrets
+        run: |
+          # Validate Secrets
+          echo Validating Repository Secrets...
+          
+          # Validate TEAMID
+          if [ -z "$TEAMID" ]; then
+            failed=true
+            echo "::error::TEAMID secret is unset or empty. Set it and try again."
+          elif [ ${#TEAMID} -ne 10 ]; then
+            failed=true
+            echo "::error::TEAMID secret is set but has wrong length. Verify that it is set correctly and try again."
+          fi
+          
+          # Validate GH_PAT
+          if [ -z "$GH_PAT" ]; then
+            failed=true
+            echo "::error::GH_PAT secret is unset or empty. Set it and try again."
+          elif [ "$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository_owner }}/Match-Secrets | jq --raw-output '.permissions.push')" != "true" ]; then
+            failed=true
+            echo "::error::GH_PAT secret is set but invalid or lacking appropriate privileges on the ${{ github.repository_owner }}/Match-Secrets repository. Verify that it is set correctly and try again."
+          fi
+          
+          # Validate FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY
+          if [ -z "$FASTLANE_ISSUER_ID" ] || [ -z "$FASTLANE_KEY_ID" ] || [ -z "$FASTLANE_KEY" ]; then
+            failed=true
+            [ -z "$FASTLANE_ISSUER_ID" ] && echo "::error::The FASTLANE_ISSUER_ID secret is unset or empty. Set it and try again."
+            [ -z "$FASTLANE_KEY_ID"    ] && echo "::error::The FASTLANE_KEY_ID secret is unset or empty. Set it and try again."
+            [ -z "$FASTLANE_KEY"       ] && echo "::error::The FASTLANE_KEY secret is unset or empty. Set it and try again."
+          elif ! echo "$FASTLANE_KEY" | openssl ec -noout >/dev/null 2>&1; then
+            failed=true
+            echo "::error::The FASTLANE_KEY secret is set but invalid. Verify that it is set correctly and try again."
+          elif ! fastlane validate_secrets; then
+            failed=true
+            echo "::error::Unable to create a valid authorization token for the App Store Connect API.\
+            Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."
+          fi
+          
+          # Validate MATCH_PASSWORD
+          if [ -z "$MATCH_PASSWORD" ]; then
+            failed=true
+            echo "::error::The MATCH_PASSWORD secret is unset or empty. Set it and try again."
+          fi
+          
+          # Exit unsuccessfully if secret validation failed.
+          if [ $failed ]; then
+            exit 2
+          fi
+        shell: bash
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -39,7 +39,7 @@ jobs:
             [ -z "$FASTLANE_ISSUER_ID" ] && echo "::error::The FASTLANE_ISSUER_ID secret is unset or empty. Set it and try again."
             [ -z "$FASTLANE_KEY_ID"    ] && echo "::error::The FASTLANE_KEY_ID secret is unset or empty. Set it and try again."
             [ -z "$FASTLANE_KEY"       ] && echo "::error::The FASTLANE_KEY secret is unset or empty. Set it and try again."
-          elif ! echo "$FASTLANE_KEY" | openssl ec -noout >/dev/null 2>&1; then
+          elif ! echo "$FASTLANE_KEY" | openssl pkcs8 -nocrypt >/dev/null; then
             failed=true
             echo "::error::The FASTLANE_KEY secret is set but invalid. Verify that it is set correctly and try again."
           elif ! fastlane validate_secrets; then

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -231,6 +231,24 @@ platform :ios do
     )
   end
 
+  desc "Validate Secrets"
+  lane :validate_secrets do
+    setup_ci if ENV['CI']
+    ENV["MATCH_READONLY"] = true.to_s
+    
+    app_store_connect_api_key(
+      key_id: "#{FASTLANE_KEY_ID}",
+      issuer_id: "#{FASTLANE_ISSUER_ID}",
+      key_content: "#{FASTLANE_KEY}"
+    )
+    
+    def find_bundle_id(identifier)
+      bundle_id = Spaceship::ConnectAPI::BundleId.find(identifier)
+    end
+
+    find_bundle_id("com.#{TEAMID}.loopkit.Loop")
+  end
+  
   desc "Nuke Certs"
   lane :nuke_certs do
     setup_ci if ENV['CI']


### PR DESCRIPTION
Adds rudimentary support for validation of repository secrets used in GitHub Actions + Fastlane build workflows.

A shared `validate_secrets.yml` has been added as a dependency of the other workflows to validate secrets prior to adding identifiers, creating certificates, or building Loop. It can also be run independently via standard workflow dispatch.

The workflow should be pretty self-explanatory, but each required repository secret is checked to verify that it is set and non-empty, then secondary validation is done upon the `GH_PAT` (via the GitHub CLI client) to ensure write permissions on the Match-Secrets repository and `FASTLANE_` secrets (via a new validate_secrets lane) to ensure that an App Store Connect API authorization with the repository secrets is successful.

I'd considered numbering the workflows, since they should be run sequentially, but I didn't want to force @marionbarker to update all of her existing screenshots in the docs, i.e.:

1. Validate Secrets
2. Add Identifiers
3. Create Certificates
4. Build Loop

Here is an example where Validate Secrets is run as a dependency of Add Identifiers and causes it to fail:
<img width="986" alt="image" src="https://user-images.githubusercontent.com/20958170/217103405-737e1156-472d-43e2-a219-cfd2ec1e7652.png">
