### PR TITLE
build_loop workflow: add template for build on push and on schedule

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -2,6 +2,13 @@ name: 4. Build Loop
 run-name: Build Loop
 on:
   workflow_dispatch:
+  
+  ## Remove the "#" sign from the beginning of the line below to get automated builds on push (code changes in your repository)
+  #push:
+
+  ## Remove the "#" sign from the beginning of the two lines below to get automated builds every two months
+  #schedule:
+    #- cron: '0 17 1 */2 *' # Runs at 17:00 UTC on the 1st in Jan, Mar, May, Jul, Sep and Nov.
 
 jobs:
   secrets:


### PR DESCRIPTION
Includes comments with instructions for un-commenting to enable builds on push and automated builds every two months:

on:  
  workflow_dispatch:
  #push:
  #schedule:
    #- cron: '0 17 1 */2 *' # Runs at 17:00 UTC on the 1st in Jan, Mar, May, Jul, Sep and Nov.
    
TestFlight builds must be renewed every 90 days, this is a way to automate repeated builds every two months. Building on push will also make updating a one-click task (sync fork in GitHub triggers build). 

LoopDocs can hold the instructions for how to activate this feature (un-commenting the relevant lines).