### PR TITLE
Add tag/branch name to build step

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -1,5 +1,5 @@
 name: 4. Build Loop
-run-name: Build Loop
+run-name: Build Loop ${{ github.ref_name }}
 on:
   workflow_dispatch:
   


### PR DESCRIPTION
This [exposes ](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)the name of the branch or tag that the Build Loop step is running. This helps show users what is being built (and thus a history) in the GitHub Actions view.

This would look something like:
![image](https://user-images.githubusercontent.com/90741/226742191-4b4a26b0-a179-49c1-a5ee-a56624b14d2f.png)
