### PR TITLE
Fastfile: Add time sensitive notifications to identifier setup

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,7 +181,8 @@ platform :ios do
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
       Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
       Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::SIRIKIT
+      Spaceship::ConnectAPI::BundleIdCapability::Type::SIRIKIT,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::USERNOTIFICATIONS_TIMESENSITIVE
     ])
 
     configure_bundle_id("Loop Intent Extension", "com.#{TEAMID}.loopkit.Loop.Loop-Intent-Extension", [

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -137,14 +137,6 @@ Note 2 - Depending on your build history, you may find some of the Identifiers a
 | WatchAppExtension | com.TEAMID.loopkit.Loop.LoopWatch.watchkitextension |
 
 
-## Add Time Sensitive Notifications to Loop App ID
-1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) on the apple developer site.
-1. Click on the "Loop" identifier
-1. Scroll down to "Time Sensitive Notifications"
-1. Tap the check box to enable Time Sensitive Notifications.
-1. Click "Save".
-1. Click "Confirm".
-
 ## Create Loop App in App Store Connect
 
 If you have created a Loop app in App Store Connect before, you can skip this section.


### PR DESCRIPTION
This removes the need to set up Time Sensitive Notifications manually for Loop. 

I could not find any actual documentation for setting USERNOTIFICATIONS_TIMESENSITIVE in fastlane, but eventually found it in the source code:

https://github.com/fastlane/fastlane/blob/0c06ab0d8049b1c4012dc5305b190c7f5f825de1/spaceship/lib/spaceship/connect_api/models/bundle_id_capability.rb#L51

The instructions in testflight.md has been updated.

@marionbarker , please update LoopDocs accordingly when this gets merged:

https://loopkit.github.io/loopdocs/gh-actions/gh-first-time/#add-or-review-configuration-for-loop-identifier