### PR TITLE
build_loop.yml: Disable upstream sync with optional repository variable

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -15,7 +15,7 @@ env:
   UPSTREAM_BRANCH: ${{ github.ref_name }} # branch on upstream repository to sync from (relpace with specific branch name if needed)
   TARGET_BRANCH: ${{ github.ref_name }} # target branch on fork to be kept in sync, and target branch on upstream to be kept alive (relpace with specific branch name if needed)
   ALIVE_BRANCH: alive
-  SYNC_UPSTREAM: 'true' # set to 'false' or 'true' to disable / enable syncing of fork with upstream repository
+  SYNC_UPSTREAM: ${{ vars.SYNC_UPSTREAM }} # set an optional "SYNC_UPSTREAM" repository variable to 'false' to disable syncing of fork with the upstream repository
 
 jobs:
   check_latest_from_upstream:
@@ -32,7 +32,7 @@ jobs:
         ref: alive
 
     - name: Sync upstream changes
-      if: ${{ env.SYNC_UPSTREAM == 'true' }} && github.repository_owner != 'LoopKit' # do not run the upstream sync action on the upstream repository
+      if: ${{ env.SYNC_UPSTREAM != 'false' && github.repository_owner != 'LoopKit' }} # do not run the upstream sync action on the upstream repository
       id: sync
       uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
       with:
@@ -79,7 +79,7 @@ jobs:
           ref: ${{ env.TARGET_BRANCH }} 
 
       - name: Sync upstream changes
-        if: ${{ env.SYNC_UPSTREAM == 'true' }} && github.repository_owner != 'LoopKit' # do not run the upstream sync action on the upstream repository
+        if: ${{ env.SYNC_UPSTREAM != 'false' && github.repository_owner != 'LoopKit' }} # do not run the upstream sync action on the upstream repository
         id: sync
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
         with:


### PR DESCRIPTION
Set an optional "SYNC_UPSTREAM" repository variable to 'false' to disable syncing of fork with the upstream repository.

Using a repository variable and not repository secret, so that the SYNC_UPSTREAM variable can be printed to logs, and displayed in repo settings (secrets are redacted and hidden).