### PR TITLE
build_loop.yml: Separate checkout repo for building

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Select Xcode version
         run: "sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer"
 
-      - name: Checkout Repo
+      - name: Checkout Repofor syncing
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT }}
@@ -103,6 +103,13 @@ jobs:
           echo ${{ steps.sync.outputs.has_new_commits }}
           echo "NEW_COMMITS=${{ steps.sync.outputs.has_new_commits }}" >> $GITHUB_OUTPUT
 
+      - name: Checkout Repo for building
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_PAT }}
+          submodules: recursive
+          ref: ${{ env.TARGET_BRANCH }}
+          
       # Customize Loop: Download and apply patches
       - name: Customize Loop
         run: |

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -71,11 +71,10 @@ jobs:
       - name: Select Xcode version
         run: "sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer"
 
-      - name: Checkout Repofor syncing
+      - name: Checkout Repo for syncing
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT }}
-          submodules: recursive
           ref: ${{ env.TARGET_BRANCH }} 
 
       - name: Sync upstream changes


### PR DESCRIPTION
The sync action does not appear to make the synced state available to the build environment. Adding another checkout step to make sure that updated code is used for building.

Checkout for syncing is done without submodules: recursive.