### PR TITLE
Browser Build "Validate Secrets" Improvements

### DIFF
--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -23,6 +23,9 @@ jobs:
           elif [ ${#TEAMID} -ne 10 ]; then
             failed=true
             echo "::error::TEAMID secret is set but has wrong length. Verify that it is set correctly and try again."
+          elif ! [[ $TEAMID =~ ^[A-Z0-9]+$ ]]; then
+            failed=true
+            echo "::error::TEAMID is set but invalid. Verify that it is set correctly (only uppercase letters and numbers) and try again."
           fi
           
           # Validate GH_PAT
@@ -32,14 +35,28 @@ jobs:
           elif [ "$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository_owner }}/Match-Secrets | jq --raw-output '.permissions.push')" != "true" ]; then
             failed=true
             echo "::error::GH_PAT secret is set but invalid or lacking appropriate privileges on the ${{ github.repository_owner }}/Match-Secrets repository. Verify that it is set correctly and try again."
+          elif [ "$(gh repo list --json name | jq --raw-output 'any(.name=="Match-Secrets")')" != "true" ]; then
+            failed=true
+            echo "::error::GH_PAT secret is set but Match-Secrets repository is missing or configured incorrectly. Verify that the repository was created and that its name is spelled correctly (uppercase 'M' for 'Match', uppercase 'S' and plural for 'Secrets', dash character '-' between the words as separator)."
           fi
           
           # Validate FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY
+          FASTLANE_KEY_ID_PATTERN='^[A-Z0-9]+$'
+          FASTLANE_ISSUER_ID_PATTERN='^\{?[A-F0-9a-f]{8}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{4}-[A-F0-9a-f]{12}\}?$'
           if [ -z "$FASTLANE_ISSUER_ID" ] || [ -z "$FASTLANE_KEY_ID" ] || [ -z "$FASTLANE_KEY" ]; then
             failed=true
             [ -z "$FASTLANE_ISSUER_ID" ] && echo "::error::The FASTLANE_ISSUER_ID secret is unset or empty. Set it and try again."
             [ -z "$FASTLANE_KEY_ID"    ] && echo "::error::The FASTLANE_KEY_ID secret is unset or empty. Set it and try again."
             [ -z "$FASTLANE_KEY"       ] && echo "::error::The FASTLANE_KEY secret is unset or empty. Set it and try again."
+          elif [ ${#FASTLANE_KEY_ID} -ne 10 ]; then
+            failed=true
+            echo "::error::FASTLANE_KEY_ID secret is set but has wrong length. Verify that it is set correctly and try again."
+          elif ! [[ $FASTLANE_KEY_ID =~ $FASTLANE_KEY_ID_PATTERN ]]; then
+            failed=true
+            echo "::error::FASTLANE_KEY_ID is set but invalid. Verify that it is set correctly (only uppercase letters and numbers) and try again."
+          elif ! [[ $FASTLANE_ISSUER_ID =~ $FASTLANE_ISSUER_ID_PATTERN ]]; then
+            failed=true
+            echo "::error::FASTLANE_ISSUER_ID is set but invalid. Verify that it is set correctly (adhering to UUID format) and try again."
           elif ! echo "$FASTLANE_KEY" | openssl pkcs8 -nocrypt >/dev/null; then
             failed=true
             echo "::error::The FASTLANE_KEY secret is set but invalid. Verify that it is set correctly and try again."


### PR DESCRIPTION
This PR is the first of probably a set of PRs over the next couple of weeks (and months?) that aim to improve Loop's browser build's validation and error handling. It further aims to provide more descriptive error messages for common errors that first time builder's come across, such as:
- Incorrectly setting up the `Match-Secrets` repository (with the current implementation if that repository is incorrectly set up the error will point toward `GH_PAT` issues)
- Spell checking for Apple Developer related secrets (`TEAMID`, `FASTLANE_KEY_ID`, `FASTLANE_ISSUER_ID`)

**Contents**:
- Adds check for `Match-Secrets` existence
- Adds `TEAMID` case sensitivity check
- Adds `FASTLANE_KEY_ID` case sensitivity check
- Adds `FASTLANE_KEY_ID` length check
- Adds `FASTLANE_ISSUER_ID` format check (adhering to UUID). 

As always, open for feedback and input. Thanks to @billybooth and @bjorkert for being great sparring partners to trade ideas back and forth with. 