### PR TITLE
GH Actions: Pass "Could not install WWDR certificate" error during validation

### DIFF
--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -123,7 +123,7 @@ jobs:
             if grep -q "bad decrypt" fastlane.log; then
               failed=true
               echo "::error::Unable to decrypt the Match-Secrets repository using the MATCH_PASSWORD secret. Verify that it is set correctly and try again."
-            elif ! grep -q "No code signing identity found" fastlane.log; then
+            elif ! grep -q -e "No code signing identity found" -e "Could not install WWDR certificate" fastlane.log; then
               failed=true
               echo "::error::Unable to create a valid authorization token for the App Store Connect API.\
               Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -49,7 +49,7 @@ jobs:
             fi
           elif [ "$(gh repo list --json name,visibility | jq --raw-output '.[] | select(.name=="Match-Secrets") | .visibility == "PUBLIC"')" == "true" ]; then
             failed=true
-            echo "::error::A 'Match-Secrets' repository was found, but it is is public. Delete it and try again (a private repository will be created for you)."
+            echo "::error::A 'Match-Secrets' repository was found, but it is is public. Change the repository visibility to private (or delete it) and try again. A private repository will be created for you if necessary."
           fi
           
           # Exit unsuccessfully if secret validation failed.


### PR DESCRIPTION
This is a small incremental improvement that prevents the occasional "Could not install WWDR certificate" error from causing validation to fail. Fastlane match during validation is executed in read-only mode and is only used to ensure that we can decrypt the `Match-Secrets` repository, so the inability to get the intermediate WWDR certificate is of no consequence here.

It also includes a small annotation change around `Match-Secrets` visibility.

Below is a collection of test runs that I think are helpful, not just for supporting this PR, but for supporting this general strategy of parsing the log and elevating specific known failures.

1. ✅ Successful validation run against an empty `Match-Secrets` repository. It passes with a log from a failed fastlane execution containing "No code signing identity found", per [validate_secrets.yml#L126](https://github.com/billybooth/LoopWorkspace/blob/ed3b6bc16f7626371c4f8f6b821477723c212859/.github/workflows/validate_secrets.yml#L126C28-L126C63):
https://github.com/billybooth/LoopWorkspace/actions/runs/5958894069/job/16184290185#step:3:159

2. ✅ Successful validation run against a populated `Match-Secrets` repository. It passes with a successful fastlane execution:
https://github.com/billybooth/LoopWorkspace/actions/runs/5966033751/job/16184820443#step:3:171

3. ❌ Failed validation run with a bad `MATCH_PASSWORD` for the populated `Match-Secrets` repository. It fails with a log from a failed fastlane execution containing "bad decrypt", per [validate_secrets.yml#L123](https://github.com/billybooth/LoopWorkspace/blob/ed3b6bc16f7626371c4f8f6b821477723c212859/.github/workflows/validate_secrets.yml#L123C24-L123C37):
https://github.com/billybooth/LoopWorkspace/actions/runs/5966083042/job/16184987221#step:3:148
    
    It provides the following error annotation:
    ```
    Unable to decrypt the Match-Secrets repository using the MATCH_PASSWORD secret. Verify that it is set correctly and try again.
    ```

4. ❌ Failed validation run with a bad (but structurally valid) `FASTLANE_KEY_ID`. It fails with a log from a failed fastlane execution that does not contain either of the known signal phrases:
https://github.com/billybooth/LoopWorkspace/actions/runs/5966157682/job/16185208832#step:3:106
    
    It provides the following error annotation:
    ```
    Unable to create a valid authorization token for the App Store Connect API. Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again.
    ```

Let me know if this is too granular, and I'll close it and include it as part of a broader PR with @dnzxy to support error checking (and possibly job retry) across the various workflows.