### PR TITLE
GH Actions: Improve secrets validation

### DIFF
--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -123,7 +123,7 @@ jobs:
             if grep -q "bad decrypt" fastlane.log; then
               failed=true
               echo "::error::Unable to decrypt the Match-Secrets repository using the MATCH_PASSWORD secret. Verify that it is set correctly and try again."
-            elif ! grep -q "No code signing identity found" fastlane.log; then
+            elif ! grep -q -e "No code signing identity found" -e "Could not install WWDR certificate" fastlane.log; then
               failed=true
               echo "::error::Unable to create a valid authorization token for the App Store Connect API.\
               Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -9,8 +9,11 @@ jobs:
     env:
       GH_PAT: ${{ secrets.GH_PAT }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
+    outputs:
+      HAS_WORKFLOW_PERMISSION: ${{ steps.access-token.outputs.has_workflow_permission }}
     steps:
       - name: Validate Access Token
+        id: access-token
         run: |
           # Validate Access Token
           
@@ -20,36 +23,42 @@ jobs:
           # Define patterns to validate the access token (GH_PAT) and distinguish between classic and fine-grained tokens.
           GH_PAT_CLASSIC_PATTERN='^ghp_[a-zA-Z0-9]{36}$'
           GH_PAT_FINE_GRAINED_PATTERN='^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$'
-
-          # Validate Fastlane Access Token (GH_PAT)
+          
+          # Validate Access Token (GH_PAT)
           if [ -z "$GH_PAT" ]; then
             failed=true
             echo "::error::The GH_PAT secret is unset or empty. Set it and try again."
-          elif [[ $GH_PAT =~ $GH_PAT_FINE_GRAINED_PATTERN ]]; then
-            echo "The 'GH_PAT' secret is a structurally valid fine-grained token."
-            
-            if ! curl -sS -f -o /dev/null -H "Authorization: token $GH_PAT" https://api.github.com; then
-              failed=true;
-              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly and try again."
-            fi
-          elif [[ $GH_PAT =~ $GH_CLASSIC_PATTERN ]]; then
-            echo "The 'GH_PAT' secret is a structurally valid classic token. Validating permission scopes..."
-            
-            # Capture the x-oauth-scopes scopes of the token.
-            if ! scopes=$(curl -sS -f -I -H "Authorization: token $GH_PAT" https://api.github.com | grep -i '^x-oauth-scopes:' | cut -d ' ' -f2-); then
-              failed=true
-              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly and try again."
-            elif [[ $scope =~ workflow ]]; then
-              echo "The GH_PAT secret has repo and workflow permissions."
-            elif [[ $scope =~ repo ]]; then
-              echo "The GH_PAT secret has repo (but not workflow) permissions."
-            else
-              failed=true
-              echo "::error::The GH_PAT secret is lacking at least the 'repo' permission scope required to access the Match-Secrets repository. Update the token permissions at https://github.com/settings/tokens (to include the 'repo' and 'workflow' scopes) and try again."
-            fi
           else
-            failed=true
-            echo "::error::The GH_PAT secret is set but invalid. Verify that it is set correctly (including the 'ghp_' or 'github_pat_' prefix) and try again."
+            if [[ $GH_PAT =~ $GH_PAT_CLASSIC_PATTERN ]]; then
+              provides_scopes=true
+              echo "The GH_PAT secret is a structurally valid classic token."
+            elif [[ $GH_PAT =~ $GH_PAT_FINE_GRAINED_PATTERN ]]; then
+              echo "The GH_PAT secret is a structurally valid fine-grained token."
+            else
+              echo "The GH_PAT secret does not have a known token format."
+            fi
+
+            # Attempt to capture the x-oauth-scopes scopes of the token.
+            if ! scopes=$(curl -sS -f -I -H "Authorization: token $GH_PAT" https://api.github.com | { grep -i '^x-oauth-scopes:' || true; } | cut -d ' ' -f2- | tr -d '\r'); then
+              failed=true
+              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly and try again."
+            elif [[ $scopes =~ workflow ]]; then
+              echo "The GH_PAT secret has repo and workflow permissions."
+              echo "has_workflow_permission=true" >> $GITHUB_OUTPUT
+            elif [[ $scopes =~ repo ]]; then
+              echo "The GH_PAT secret has repo (but not workflow) permissions."
+            elif [ $provides_scopes ]; then
+              failed=true
+              if [ -z "$scopes" ]; then
+                echo "The GH_PAT secret is valid and can be used to connect to GitHub, but it does not provide any permission scopes."
+              else
+                echo "The GH_PAT secret is valid and can be used to connect to GitHub, but it only provides the following permission scopes: $scopes"
+              fi
+              echo "::error::The GH_PAT secret is lacking at least the 'repo' permission scope required to access the Match-Secrets repository. Update the token permissions at https://github.com/settings/tokens (to include the 'repo' and 'workflow' scopes) and try again."
+            else
+              echo "The GH_PAT secret is valid and can be used to connect to GitHub, but it does not provide inspectable scopes. Assuming that the 'repo' and 'workflow' permission scopes required to access the Match-Secrets repository and perform automations are present."
+              echo "has_workflow_permission=true" >> $GITHUB_OUTPUT
+            fi
           fi
           
           # Exit unsuccessfully if secret validation failed.
@@ -97,7 +106,7 @@ jobs:
   
   validate-fastlane-secrets:
     name: Fastlane
-    needs: validate-match-secrets
+    needs: [validate-access-token, validate-match-secrets]
     runs-on: macos-13
     env:
       GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -45,7 +45,7 @@ jobs:
               if [ $unknown_format ]; then
                 echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly (including the 'ghp_' or 'github_pat_' prefix) and try again."
               else
-                echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that the token exists and has not expired at https://github.com/settings/tokens (and, if necessary, regenerate/create a new token and update the secret) and try again."
+                echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that the token exists and has not expired at https://github.com/settings/tokens. If necessary, regenerate or create a new token (and update the secret), then try again."
               fi
             elif [[ $scopes =~ workflow ]]; then
               echo "The GH_PAT secret has repo and workflow permissions."

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -87,7 +87,7 @@ jobs:
             failed=true
             echo "::error::A '${{ github.repository_owner }}/Match-Secrets' repository was found, but it is is public. Change the repository visibility to private (or delete it) and try again. If necessary, a private repository will be created for you."
           else
-            echo "Found a private '${{ github.repository_owner }}/Match-Secrets' repository to use.
+            echo "Found a private '${{ github.repository_owner }}/Match-Secrets' repository to use."
           fi
           
           # Exit unsuccessfully if secret validation failed.

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -37,19 +37,27 @@ jobs:
       - name: Validate Match-Secrets
         run: |
           # Validate Match-Secrets
-          if [ "$(gh repo list --json name | jq --raw-output 'any(.name=="Match-Secrets")')" != "true" ]; then
-            echo "A 'Match-Secrets' repository could not be found. Attempting to create one...";
+          
+          # Ensure that gh exit codes are handled when output is piped.
+          set -o pipefail
+          
+          # If a Match-Secrets repository does not exist, attempt to create one.
+          if ! visibility=$(gh repo view ${{ github.repository_owner }}/Match-Secrets --json visibility | jq --raw-output '.visibility | ascii_downcase'); then
+            echo "A '${{ github.repository_owner }}/Match-Secrets' repository could not be found using the GH_PAT secret. Attempting to create one..."
             
-            if gh repo create Match-Secrets --private >/dev/null && [ "$(gh repo list --json name,visibility | jq --raw-output '.[] | select(.name=="Match-Secrets") | .visibility == "PRIVATE"')" == "true" ]; then
-              echo "Created a private 'Match-Secrets' repository."
+            # Create a private Match-Secrets repository and verify that it exists and that it is private.
+            if gh repo create ${{ github.repository_owner }}/Match-Secrets --private >/dev/null && [ "$(gh repo view ${{ github.repository_owner }}/Match-Secrets --json visibility | jq --raw-output '.visibility | ascii_downcase')" == "private" ]; then
+              echo "Created a private '${{ github.repository_owner }}/Match-Secrets' repository."
             else
               failed=true
-              echo "::error::Cannot access or create a private 'Match-Secrets' repository. The GH_PAT secret is lacking at least the 'repo' permission scope required to access or create the repository.\
-              Verify that token permissions are set correctly (or update them) at https://github.com/settings/tokens and try again."
+              echo "::error::Unable to create a private '${{ github.repository_owner }}/Match-Secrets' repository. Create a private 'Match-Secrets' repository manually and try again. If a private 'Match-Secrets' repository already exists, verify that the token permissions of the GH_PAT are set correctly (or update them) at https://github.com/settings/tokens and try again."
             fi
-          elif [ "$(gh repo list --json name,visibility | jq --raw-output '.[] | select(.name=="Match-Secrets") | .visibility == "PUBLIC"')" == "true" ]; then
+          # Otherwise, if a Match-Secrets repository exists, but it is public, cause validation to fail.
+          elif [[ "$visibility" == "public" ]]; then
             failed=true
-            echo "::error::A 'Match-Secrets' repository was found, but it is is public. Change the repository visibility to private (or delete it) and try again. A private repository will be created for you if necessary."
+            echo "::error::A '${{ github.repository_owner }}/Match-Secrets' repository was found, but it is is public. Change the repository visibility to private (or delete it) and try again. If necessary, a private repository will be created for you."
+          else
+            echo "Found a private '${{ github.repository_owner }}/Match-Secrets' repository to use.
           fi
           
           # Exit unsuccessfully if secret validation failed.

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -12,14 +12,44 @@ jobs:
     steps:
       - name: Validate Access Token
         run: |
+          # Validate Access Token
+          
+          # Ensure that gh exit codes are handled when output is piped.
+          set -o pipefail
+          
+          # Define patterns to validate the access token (GH_PAT) and distinguish between classic and fine-grained tokens.
+          GH_PAT_CLASSIC_PATTERN='^ghp_[a-zA-Z0-9]{36}$'
+          GH_PAT_FINE_GRAINED_PATTERN='^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$'
+
           # Validate Fastlane Access Token (GH_PAT)
           if [ -z "$GH_PAT" ]; then
             failed=true
             echo "::error::The GH_PAT secret is unset or empty. Set it and try again."
-          elif [ "$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository_owner }}/LoopWorkspace | jq --raw-output '.permissions.push')" != "true" ]; then
+          elif [[ $GH_PAT =~ $GH_PAT_FINE_GRAINED_PATTERN ]]; then
+            echo "The 'GH_PAT' secret is a structurally valid fine-grained token."
+            
+            if ! curl -sS -f -o /dev/null -H "Authorization: token $GH_PAT" https://api.github.com; then
+              failed=true;
+              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly and try again."
+            fi
+          elif [[ $GH_PAT =~ $GH_CLASSIC_PATTERN ]]; then
+            echo "The 'GH_PAT' secret is a structurally valid classic token. Validating permission scopes..."
+            
+            # Capture the x-oauth-scopes scopes of the token.
+            if ! scopes=$(curl -sS -f -I -H "Authorization: token $GH_PAT" https://api.github.com | grep -i '^x-oauth-scopes:' | cut -d ' ' -f2-); then
+              failed=true
+              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly and try again."
+            elif [[ $scope =~ workflow ]]; then
+              echo "The GH_PAT secret has repo and workflow permissions."
+            elif [[ $scope =~ repo ]]; then
+              echo "The GH_PAT secret has repo (but not workflow) permissions."
+            else
+              failed=true
+              echo "::error::The GH_PAT secret is lacking at least the 'repo' permission scope required to access the Match-Secrets repository. Update the token permissions at https://github.com/settings/tokens (to include the 'repo' and 'workflow' scopes) and try again."
+            fi
+          else
             failed=true
-            echo "::error::The GH_PAT secret is set but invalid or lacking at least 'repo' permission scope ('repo, workflow' is okay too).\
-            Verify that token permissions are set correctly (or update them) at https://github.com/settings/tokens and try again."
+            echo "::error::The GH_PAT secret is set but invalid. Verify that it is set correctly (including the 'ghp_' or 'github_pat_' prefix) and try again."
           fi
           
           # Exit unsuccessfully if secret validation failed.

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -41,7 +41,7 @@ jobs:
             # Attempt to capture the x-oauth-scopes scopes of the token.
             if ! scopes=$(curl -sS -f -I -H "Authorization: token $GH_PAT" https://api.github.com | { grep -i '^x-oauth-scopes:' || true; } | cut -d ' ' -f2- | tr -d '\r'); then
               failed=true
-              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly and try again."
+              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly (including the 'ghp_' or 'github_pat_' prefix) and try again."
             elif [[ $scopes =~ workflow ]]; then
               echo "The GH_PAT secret has repo and workflow permissions."
               echo "has_workflow_permission=true" >> $GITHUB_OUTPUT
@@ -94,7 +94,7 @@ jobs:
           # Otherwise, if a Match-Secrets repository exists, but it is public, cause validation to fail.
           elif [[ "$visibility" == "public" ]]; then
             failed=true
-            echo "::error::A '${{ github.repository_owner }}/Match-Secrets' repository was found, but it is is public. Change the repository visibility to private (or delete it) and try again. If necessary, a private repository will be created for you."
+            echo "::error::A '${{ github.repository_owner }}/Match-Secrets' repository was found, but it is public. Change the repository visibility to private (or delete it) and try again. If necessary, a private repository will be created for you."
           else
             echo "Found a private '${{ github.repository_owner }}/Match-Secrets' repository to use."
           fi

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -170,10 +170,12 @@ jobs:
             if grep -q "bad decrypt" fastlane.log; then
               failed=true
               echo "::error::Unable to decrypt the Match-Secrets repository using the MATCH_PASSWORD secret. Verify that it is set correctly and try again."
+            elif grep -q -e "required agreement" -e "license agreement" fastlane.log; then
+              failed=true
+              echo "::error::Unable to create a valid authorization token for the App Store Connect API. Verify that the latest developer program license agreement has been accepted at https://developer.apple.com/account (review and accept any updated agreement), then wait a few minutes for changes to propagate and try again."
             elif ! grep -q -e "No code signing identity found" -e "Could not install WWDR certificate" fastlane.log; then
               failed=true
-              echo "::error::Unable to create a valid authorization token for the App Store Connect API.\
-              Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."
+              echo "::error::Unable to create a valid authorization token for the App Store Connect API. Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."
             fi
           fi
           

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -35,13 +35,18 @@ jobs:
             elif [[ $GH_PAT =~ $GH_PAT_FINE_GRAINED_PATTERN ]]; then
               echo "The GH_PAT secret is a structurally valid fine-grained token."
             else
+              unknown_format=true
               echo "The GH_PAT secret does not have a known token format."
             fi
-
+            
             # Attempt to capture the x-oauth-scopes scopes of the token.
             if ! scopes=$(curl -sS -f -I -H "Authorization: token $GH_PAT" https://api.github.com | { grep -i '^x-oauth-scopes:' || true; } | cut -d ' ' -f2- | tr -d '\r'); then
               failed=true
-              echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly (including the 'ghp_' or 'github_pat_' prefix) and try again."
+              if [ $unknown_format ]; then
+                echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that it is set correctly (including the 'ghp_' or 'github_pat_' prefix) and try again."
+              else
+                echo "::error::Unable to connect to GitHub using the GH_PAT secret. Verify that the token exists and has not expired at https://github.com/settings/tokens (and, if necessary, regenerate/create a new token and update the secret) and try again."
+              fi
             elif [[ $scopes =~ workflow ]]; then
               echo "The GH_PAT secret has repo and workflow permissions."
               echo "has_workflow_permission=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -49,7 +49,7 @@ jobs:
             fi
           elif [ "$(gh repo list --json name,visibility | jq --raw-output '.[] | select(.name=="Match-Secrets") | .visibility == "PUBLIC"')" == "true" ]; then
             failed=true
-            echo "::error::A 'Match-Secrets' repository was found, but it is is public. Delete it and try again (a private repository will be created for you)."
+            echo "::error::A 'Match-Secrets' repository was found, but it is is public. Change the repository visibility to private (or delete it) and try again. A private repository will be created for you if necessary."
           fi
           
           # Exit unsuccessfully if secret validation failed.


### PR DESCRIPTION
This PR addresses a couple of issues and provides a couple of enhancements:

Issues addressed:
1. Previously, the GH_PAT permissions were not validated correctly. The permissions of the repository owner were validated rather than the permissions of the GH_PAT token.
2. Previously, the Match-Secrets repository check was evaluating a Match-Secrets repository under the owner of the token rather than the owner of the current LoopWorkspace repository. This could result in Fastlane using a different Match-Secrets repository than the validation routine, i.e., `${{ github.repository_owner }}/Match-Secrets` is used by Fastlane and `<GH_PAT owner>/Match-Secrets` was used for validation.

Enhancements provided:
1. Provide an appropriate annotation when there is an unaccepted update to the apple developer program license agreement.
2. Allow validate_secrets.yml to provide `HAS_WORKFLOW_PERMISSION` output when called as a reusable workflow.
3. Allow "Could not install WWDR certificate" error to pass validation (until this addressed upstream by Fastlane).