### PR TITLE
Fix cron schedule for automated sync and build

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -7,7 +7,7 @@ on:
   #push:
   
   schedule:
-    - cron: '0 8 * * 3' # Checks for updates at 04:00 UTC every Wednesday
+    - cron: '0 8 * * 3' # Checks for updates at 08:00 UTC every Wednesday
     - cron: '0 6 1 * *' # Builds the app on the 1st of every month at 06:00 UTC
 
 env:

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -7,8 +7,8 @@ on:
   #push:
   
   schedule:
-    - cron: '0 8 * * 3' # Checks for updates at 08:00 UTC every Wednesday
-    - cron: '0 8 1 * 6' # Builds the app on the 1st Saturday every month at 08:00 UTC
+    - cron: '0 8 * * 3' # Checks for updates at 04:00 UTC every Wednesday
+    - cron: '0 6 1 * *' # Builds the app on the 1st of every month at 06:00 UTC
 
 env:
   UPSTREAM_REPO: LoopKit/LoopWorkspace
@@ -162,7 +162,7 @@ jobs:
     if: | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
         github.event_name == 'workflow_dispatch' ||
         (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-          (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '0 8 1 * 6') ||
+          (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '0 6 1 * *') ||
           (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
         )
     steps:

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -11,7 +11,7 @@ These instructions allow you to build Loop without having access to a Mac.
 > 
 > This new version of the browser build **defaults to** automatically updating and building a new version of Loop according to this schedule:
 > - automatically checks for updates weekly on Wednesdays and if updates are found, it will build a new version of the app
-> - automatically builds once a month regardless of whether there are updates on the first Saturday of the month
+> - automatically builds once a month regardless of whether there are updates on the first of the month
 > - with each scheduled run (weekly or monthly), a successful Build Loop log appears - if the time is very short, it did not need to build - only the long actions (>20 minutes) built a new Loop app
 > 
 > It also creates an alive branch, if you don't already have one. See [Why do I have an alive branch?](#why-do-i-have-an-alive-branch).
@@ -262,8 +262,8 @@ Note that the weekly and monthly Build Loop actions will continue, but the actio
 Your build will run on the following conditions:
 - Default behaviour:
     - Run weekly, every Wednesday at 08:00 UTC to check for changes; if there are changes, it will update your repository and build
-    - Run monthly, every first Saturday of the month at 08:00 UTC, if there are changes, it will update your repository; regardless of changes, it will build
+    - Run monthly, every first of the month at 06:00 UTC, if there are changes, it will update your repository; regardless of changes, it will build
     - Each time the action runs, it makes a keep-alive commit to the `alive` branch if necessary
 - If you disable any automation (both variables set to `false`), no updates, keep-alive or building happens when Build Loop runs
-- If you disabled just scheduled synchronization (`SCHEDULED_SYNC` set to`false`), it will only run once a month, on the first Saturday of the month, no update will happen; keep-alive will run
+- If you disabled just scheduled synchronization (`SCHEDULED_SYNC` set to`false`), it will only run once a month, on the first of the month, no update will happen; keep-alive will run
 - If you disabled just scheduled build (`SCHEDULED_BUILD` set to`false`), it will run once weekly, every Wednesday, to check for changes; if there are changes, it will update and build; keep-alive will run


### PR DESCRIPTION
This PR fixes an issue that was brought into Loop `dev` with [PR71](https://github.com/LoopKit/LoopWorkspace/pull/71/). 
The intention was to get a scheduled action run every Wednesday and a scheduled sync+build every first Saturday of the month. The issue here lies within the second cron tab `0 8 1 * 6` which *actually* triggers the action at 08:00 UTC on 1st day-of-month *and* on Saturday, thus resulting in more than the intended runs. 

Suggested fix goes as follows:
- Scheduled build at 1st day-of-month at 6am UTC 
- Scheduled sync every Wednesday at 8am UTC

This results in the following behaviour if Looper is running the opt-out everything-enabled automated build + sync
- it will check for changes, sync and build on every first of the month at 6am UTC
- it will check for changes, if present sync and build, every Wednesday 8am UTC
- on days where 1st of the month and Wednesday are the same day and there are changes, it checks for changes, syncs and builds at 6am and it performs a second run at 8am that will only check for commits, find none and skip build (unless there is a release in that 2 hour window, which I think is very unlikely)
- Until end of 2026, a Wednesday is the first of the month for 11/23, 05/24, 01/25, 10/25, 04/26 and 07/26


** Side note
In a future development stage of automated sync+build, the automation part for the sync will most likely be moved to another workflow and be refactored to a reusable workflow. Subsequently, it may evolve so that the scheduling can be controlled even more granularly at some point in the future.