### PR TITLE
Add branch+commit to "What to Test" field in TestFlight.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,6 +156,7 @@ platform :ios do
       skip_submission: false,
       ipa: "Loop.ipa",
       skip_waiting_for_build_processing: true,
+      changelog: git_branch+" "+last_git_commit[:abbreviated_commit_hash],
     )
   end
 


### PR DESCRIPTION
Adds the branch and last commit to the "What to Test" field in TestFlight to more easily determine the version of each available option in your TestFlight. 

![IMG_3179](https://github.com/LoopKit/LoopWorkspace/assets/82073483/d49a447d-28fb-4599-97bb-f9172f2ab081)
