### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -20,7 +20,7 @@ jobs:
       
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -97,7 +97,7 @@ jobs:
       if: |
         needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
         (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ secrets.GH_PAT }}
         ref: alive
@@ -173,7 +173,7 @@ jobs:
         if: |
           needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
           vars.SCHEDULED_SYNC != 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
           ref: ${{ env.TARGET_BRANCH }} 
@@ -213,7 +213,7 @@ jobs:
           echo "NEW_COMMITS=${{ steps.sync.outputs.has_new_commits }}" >> $GITHUB_OUTPUT
 
       - name: Checkout Repo for building
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
           submodules: recursive

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -20,7 +20,7 @@ jobs:
       
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -123,7 +123,7 @@ jobs:
       TEAMID: ${{ secrets.TEAMID }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Install Project Dependencies
         run: bundle install


### PR DESCRIPTION
This will remove the warning in Actions:
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`