### PR TITLE
Change GITHUB_TOKEN to user-created GH_PAT

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Check for alive branch
       if: steps.workflow-permission.outputs.has_permission == 'true'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         if [[ "$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository_owner }}/LoopWorkspace/branches | jq --raw-output 'any(.name=="alive")')" == "true" ]]; then
           echo "Branch 'alive' exists."
@@ -66,7 +66,7 @@ jobs:
     - name: Create alive branch
       if: env.ALIVE_BRANCH_EXISTS == 'false'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       run: |
         # Get ref for LoopKit/LoopWorkspace:dev
         SHA=$(curl -sS https://api.github.com/repos/${{ env.UPSTREAM_REPO }}/git/refs \


### PR DESCRIPTION
Basing this change on multiple issue reports on Facebook (Looped and Loop and Learn groups). Upon further investigation, the issue lies with the default, auto-created `GITHUB_TOKEN` GitHub provides for all actions.

This PR fixes permission issues where the GH api responds with:

```sh
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/git/refs#create-a-reference"}
Error: Process completed with exit code 1.
```

because the default, auto-created GITHUB_TOKEN cannot be given appropriate content write permissions to create branches in the owner's repository. Subsequently, the automated creation of the `alive` branch fails. 

We are using the same `GH_PAT` (user-created) token in the [Validate-Secrets](https://github.com/LoopKit/LoopWorkspace/blob/db751fef7b1b349aa0eba12515d53251017a191f/.github/workflows/validate_secrets.yml#L79) action, whereby this PR consolidates token usage.

Up for discussion: Should we also use the `gh` CLI tool for `alive` branch creation in `build_loop.yaml` as we are in `validate_secrets.yaml`. Maybe it is out of scope for this PR as it fixes apparent issues users currently come across when switching from Loop main to dev utilizing browser build. Maybe it’s not. 