### PR TITLE
Remove initial error about logging in Xcode debug log

### DIFF
--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -561,6 +561,13 @@
             ReferencedContainer = "container:Loop/Loop.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
When building using Mac and Xcode to an iOS 17.5.1 phone, this error message is shown in red as the first item of the Xcode debug log.

```
Logging Error: Failed to initialize logging system. Log messages may be missing. If this issue persists, try setting IDEPreferLogStreaming=YES in the active scheme actions environment variables.
```

I followed the directions to obtain the scheme modifications found in this PR.

The initial error message is no longer seen.
