### PR TITLE
Add workflow (nuke_certs) for Annual Certificates Reset

### DIFF
--- a/.github/workflows/nuke_certs.yml
+++ b/.github/workflows/nuke_certs.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate:
+    name: Validate
+    uses: ./.github/workflows/validate_secrets.yml
+    secrets: inherit
+
   nuke_certs:
     runs-on: macos-14
     steps:

--- a/.github/workflows/nuke_certs.yml
+++ b/.github/workflows/nuke_certs.yml
@@ -1,0 +1,44 @@
+name: 9. Annual Certificates Reset
+on:
+  workflow_dispatch:
+
+jobs:
+  nuke_certs:
+    runs-on: macos-14
+    steps:
+      # Uncomment to manually select latest Xcode if needed
+      #- name: Select Latest Xcode
+      #  run: "sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer"
+      
+      # Checks-out the repo
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        
+      # Patch Fastlane Match to not print tables
+      - name: Patch Match Tables
+        run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+      
+      # Patch Fastlane Match nuke to not print tables
+      - name: Patch Nuke Tables
+        run: find /usr/local/lib/ruby/gems -name nuke.rb | xargs sed -i "" "/     print_tables/d"
+        
+      # Patch Fastlane Match nuke to not print other misc messages
+      - name: Patch Other Nuke Info
+        run: |
+           find /usr/local/lib/ruby/gems -name nuke.rb | xargs sed -i "" '/UI.message("Deleting profile /d'
+           find /usr/local/lib/ruby/gems -name nuke.rb | xargs sed -i "" '/UI.message("Certificate /d'
+           find /usr/local/lib/ruby/gems -name nuke.rb | xargs sed -i "" '/UI.message("Revoking certificate /d'
+           find /usr/local/lib/ruby/gems -name nuke.rb | xargs sed -i "" '/UI.message("Deleting file /d'
+        
+      # Remove all development certificates for Loop from Apple developer account
+      - name: Fastlane Nuke Certificates
+        run: fastlane nuke_certs
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+          FASTLANE_SKIP_ALL_LANE_SUMMARIES: "true"

--- a/.github/workflows/nuke_certs.yml
+++ b/.github/workflows/nuke_certs.yml
@@ -1,4 +1,5 @@
 name: 9. Annual Certificates Reset
+run-name: Annual Certificates Reset (${{ github.ref_name }})
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
## Background
The manual directions in LoopDocs are difficult for users to implement.
The nuke_certs.yml was proposed by @ps2 at some time in the past when we were not quite sure of the steps.
I found a version of his code and updated it for macos-14 and node20.
The job shows up as `9. Annual Certificates Reset`.

## Details
Adding this workflow will change the section linked below to be:

When certificates expire
1. Run the action for Annual Certificates Reset
2. Then for every app built with browser, run the actions to Create Certificates followed by Build

## LoopDocs link
Without this workflow, users need to follow these instructions:
* https://loopkit.github.io/loopdocs/browser/bb-update/#manual-steps-to-renew-your-distribution-certificate