### PR TITLE
disable keepalive-workflow while the repo is not available

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -171,12 +171,14 @@ jobs:
 
       # Keep repository "alive": add empty commits to ALIVE_BRANCH after "time_elapsed" days of inactivity to avoid inactivation of scheduled workflows
       - name: Keep alive
-        if: |
-          needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-          (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-        uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
-        with:
-          time_elapsed: 20 # Time elapsed from the previous commit to trigger a new automated commit (in days)
+        run: |
+          echo "Keep Alive temporarily removed while gautamkrishnar/keepalive-workflow is not available"
+      #  if: |
+      #    needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
+      #    (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
+      #  uses: gautamkrishnar/keepalive-workflow@v1 # using the workflow with default settings
+      #  with:
+      #    time_elapsed: 20 # Time elapsed from the previous commit to trigger a new automated commit (in days)
 
       - name: Show scheduled build configuration message
         if: needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION != 'true'


### PR DESCRIPTION
## Purpose

The `gautamkrishnar/keepalive-workflow` has been taken down by GitHub. ~~We do not know if this is permanent or not.~~ We now know this is a permanent change.
This PR makes a minimal change to the current build_loop.yml which renables building with GitHub actions.

## Method

Comment out the section that is not available and insert an echo for the log file.

~~If we later decide to remove the keepalive process entirely, a bigger change will be made to the build_loop.yml and to the documentation. But for now, I went with the minimum change to make it work.~~

~~In 60 days, we will need to make a final decision about keepalive.~~

At a later time, the whole logic thread for automatic build will be reviewed, updated and documented.

## Testing

This was testing using the loopdocs-tester username both as a branch named disable-keepalive and by renaming it to dev to test the parts of the code that create the alive-xxx branches if they do not exist.