### PR TITLE
Release/3.8.2

### DIFF
--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -10,9 +10,9 @@ on:
   #   affect other OS apps if run simultaneously.
   # Each OS needs a time of day distinct from other apps, LoopWorkspace uses 9 every Wed and 7 every 1st of month
   schedule:
-    # avoid starting an action at hh:00 when GitHub resources are impacted
-    - cron: "33 9 * * 3" # Checks for updates at 09:33 UTC every Wednesday
-    - cron: "33 7 1 * *" # Builds the app on the 1st of every month at 07:33 UTC
+    # avoid starting an action at times when GitHub resources are impacted
+    - cron: "33 9 * * 0" # Checks for updates at 09:33 UTC every Sunday
+    - cron: "33 7 8-14 * 6" # Builds the app on the second Saturday of each month at 07:33 UTC
 
 env:
   UPSTREAM_REPO: LoopKit/LoopWorkspace
@@ -201,7 +201,7 @@ jobs:
       | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '33 7 1 * *') ||
+        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '33 7 8-14 * 6') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:

--- a/VersionOverride.xcconfig
+++ b/VersionOverride.xcconfig
@@ -8,5 +8,5 @@
 
 // Version [for DIY Loop]
 //   configure the version number in LoopWorkspace
-LOOP_MARKETING_VERSION = 3.8.1
+LOOP_MARKETING_VERSION = 3.8.2
 CURRENT_PROJECT_VERSION = 57


### PR DESCRIPTION
## Purpose:

Update to release v3.8.2

## Method:

Start work on the PR and add commits to include the following updates:
* Bump version to 3.8.2
* Shift the scheduled builds to be times when GitHub is historically less busy
   * Monthly builds on the second Saturday of each month
   * Weekly checks for updates every Sunday

Planned additions coming soon:
* Bring in the localization updates currently residing in the `lokalise_after_iaps_crowdin` branch after the PRs for the submodules are all merged
   * Increases the translated strings by bringing in submodule translations from iAPS
   * Adds 3 languages, Checken, Hungarian and Ukranian  