### PR TITLE
Add support for multiple bundle IDs

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -42,6 +42,7 @@ jobs:
         run: bundle exec fastlane identifiers
         env:
           TEAMID: ${{ secrets.TEAMID }}
+          TEAMID_SUFFIX: ${{ vars.TEAMID_SUFFIX }}
           GH_PAT: ${{ secrets.GH_PAT }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -235,6 +235,7 @@ jobs:
         run: bundle exec fastlane build_loop
         env:
           TEAMID: ${{ secrets.TEAMID }}
+          TEAMID_SUFFIX: ${{ vars.TEAMID_SUFFIX }}
           GH_PAT: ${{ secrets.GH_PAT }}
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
           FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
@@ -246,6 +247,7 @@ jobs:
         run: bundle exec fastlane release
         env:
           TEAMID: ${{ secrets.TEAMID }}
+          TEAMID_SUFFIX: ${{ vars.TEAMID_SUFFIX }}
           GH_PAT: ${{ secrets.GH_PAT }}
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
           FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -5,6 +5,7 @@ on: [workflow_call, workflow_dispatch]
 
 env:
   TEAMID: ${{ secrets.TEAMID }}
+  TEAMID_SUFFIX: ${{ vars.TEAMID_SUFFIX }}
   GH_PAT: ${{ secrets.GH_PAT }}
   GH_TOKEN: ${{ secrets.GH_PAT }}
   MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -114,6 +114,7 @@ jobs:
       FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       TEAMID: ${{ secrets.TEAMID }}
+      TEAMID_SUFFIX: ${{ vars.TEAMID_SUFFIX }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -139,6 +140,17 @@ jobs:
           elif ! [[ $TEAMID =~ ^[A-Z0-9]+$ ]]; then
             failed=true
             echo "::error::The TEAMID secret is set but invalid. Verify that it is set correctly (only uppercase letters and numbers) and try again."
+          fi
+
+          # Validate TEAMID_SUFFIX
+          if [ -z "$TEAMID_SUFFIX" ]; then
+            echo "::notice::No TEAMID_SUFFIX variable is set."
+          elif [ ${#TEAMID_SUFFIX} -gt 5 ]; then
+            failed=true
+            echo "::error::The TEAMID_SUFFIX variable is set but is too long. Verify that it the length is between 1 and 5 characters and try again."
+          elif ! [[ $TEAMID_SUFFIX =~ ^[A-Z0-9]+$ ]]; then
+            failed=true
+            echo "::error::The TEAMID_SUFFIX variable is set but invalid. Verify that it is set correctly (only uppercase letters and numbers) and try again."
           fi
 
           # Validate MATCH_PASSWORD

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -123,7 +123,7 @@ platform :ios do
       output_name: "Loop.ipa",
       configuration: "Release",
       destination: 'generic/platform=iOS',
-      buildlog_path: 'buildlog'
+      buildlog_path: 'buildlog',
       xcargs: "MAIN_APP_BUNDLE_IDENTIFIER=com.#{TEAMID_SUFFIX}.loopkit.Loop"
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,7 +12,8 @@
 
 default_platform(:ios)
 
-TEAMID = ENV["TEAMID_SUFFIX"].to_s.empty? ? "#{ENV["TEAMID"]}" : "#{ENV["TEAMID"]}-#{ENV["TEAMID_SUFFIX"]}"
+TEAMID = ENV["TEAMID"]
+TEAMID_SUFFIX = ENV["TEAMID_SUFFIX"].to_s.empty? ? "#{ENV["TEAMID"]}" : "#{ENV["TEAMID"]}-#{ENV["TEAMID_SUFFIX"]}"
 GH_PAT = ENV["GH_PAT"]
 GITHUB_WORKSPACE = ENV["GITHUB_WORKSPACE"]
 GITHUB_REPOSITORY_OWNER = ENV["GITHUB_REPOSITORY_OWNER"]
@@ -40,7 +41,7 @@ platform :ios do
     )
 
     previous_build_number = latest_testflight_build_number(
-      app_identifier: "com.#{TEAMID}.loopkit.Loop",
+      app_identifier: "com.#{TEAMID_SUFFIX}.loopkit.Loop",
       api_key: api_key,
     )
 
@@ -55,12 +56,12 @@ platform :ios do
       type: "appstore",
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
       app_identifier: [
-        "com.#{TEAMID}.loopkit.Loop", 
-        "com.#{TEAMID}.loopkit.Loop.statuswidget", 
-        "com.#{TEAMID}.loopkit.Loop.LoopWatch.watchkitextension", 
-        "com.#{TEAMID}.loopkit.Loop.LoopWatch", 
-        "com.#{TEAMID}.loopkit.Loop.Loop-Intent-Extension",
-        "com.#{TEAMID}.loopkit.Loop.LoopWidgetExtension"
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.statuswidget", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch.watchkitextension", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.Loop-Intent-Extension",
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWidgetExtension"
       ]
     )
 
@@ -70,7 +71,7 @@ platform :ios do
 
     update_code_signing_settings(
       path: "#{GITHUB_WORKSPACE}/Loop/Loop.xcodeproj",
-      profile_name: mapping["com.#{TEAMID}.loopkit.Loop"],
+      profile_name: mapping["com.#{TEAMID_SUFFIX}.loopkit.Loop"],
       code_sign_identity: "iPhone Distribution",
       targets: ["Loop"]
     )
@@ -83,35 +84,35 @@ platform :ios do
 
     update_code_signing_settings(
       path: "#{GITHUB_WORKSPACE}/Loop/Loop.xcodeproj",
-      profile_name: mapping["com.#{TEAMID}.loopkit.Loop.statuswidget"],
+      profile_name: mapping["com.#{TEAMID_SUFFIX}.loopkit.Loop.statuswidget"],
       code_sign_identity: "iPhone Distribution",
       targets: ["Loop Status Extension"]
     )
     
     update_code_signing_settings(
       path: "#{GITHUB_WORKSPACE}/Loop/Loop.xcodeproj",
-      profile_name: mapping["com.#{TEAMID}.loopkit.Loop.LoopWatch.watchkitextension"],
+      profile_name: mapping["com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch.watchkitextension"],
       code_sign_identity: "iPhone Distribution",
       targets: ["WatchApp Extension"]
     )
     
     update_code_signing_settings(
       path: "#{GITHUB_WORKSPACE}/Loop/Loop.xcodeproj",
-      profile_name: mapping["com.#{TEAMID}.loopkit.Loop.LoopWatch"],
+      profile_name: mapping["com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch"],
       code_sign_identity: "iPhone Distribution",
       targets: ["WatchApp"]
     )
     
     update_code_signing_settings(
       path: "#{GITHUB_WORKSPACE}/Loop/Loop.xcodeproj",
-      profile_name: mapping["com.#{TEAMID}.loopkit.Loop.Loop-Intent-Extension"],
+      profile_name: mapping["com.#{TEAMID_SUFFIX}.loopkit.Loop.Loop-Intent-Extension"],
       code_sign_identity: "iPhone Distribution",
       targets: ["Loop Intent Extension"]
     )
     
     update_code_signing_settings(
       path: "#{GITHUB_WORKSPACE}/Loop/Loop.xcodeproj",
-      profile_name: mapping["com.#{TEAMID}.loopkit.Loop.LoopWidgetExtension"],
+      profile_name: mapping["com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWidgetExtension"],
       code_sign_identity: "iPhone Distribution",
       targets: ["Loop Widget Extension"]
     )
@@ -123,7 +124,7 @@ platform :ios do
       configuration: "Release",
       destination: 'generic/platform=iOS',
       buildlog_path: 'buildlog'
-      xcargs: "MAIN_APP_BUNDLE_IDENTIFIER=com.#{TEAMID}.loopkit.Loop"
+      xcargs: "MAIN_APP_BUNDLE_IDENTIFIER=com.#{TEAMID_SUFFIX}.loopkit.Loop"
     )
 
     copy_artifacts(
@@ -171,7 +172,7 @@ platform :ios do
       end
     end
 
-    configure_bundle_id("Loop", "com.#{TEAMID}.loopkit.Loop", [
+    configure_bundle_id("Loop", "com.#{TEAMID_SUFFIX}.loopkit.Loop", [
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
       Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
       Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS,
@@ -179,22 +180,22 @@ platform :ios do
       Spaceship::ConnectAPI::BundleIdCapability::Type::NFC_TAG_READING
     ])
 
-    configure_bundle_id("Loop Intent Extension", "com.#{TEAMID}.loopkit.Loop.Loop-Intent-Extension", [
+    configure_bundle_id("Loop Intent Extension", "com.#{TEAMID_SUFFIX}.loopkit.Loop.Loop-Intent-Extension", [
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
     ])
 
-    configure_bundle_id("Loop Status Extension", "com.#{TEAMID}.loopkit.Loop.statuswidget", [
+    configure_bundle_id("Loop Status Extension", "com.#{TEAMID_SUFFIX}.loopkit.Loop.statuswidget", [
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
     ])
 
-    configure_bundle_id("WatchApp", "com.#{TEAMID}.loopkit.Loop.LoopWatch", [])
+    configure_bundle_id("WatchApp", "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch", [])
 
-    configure_bundle_id("WatchApp Extension", "com.#{TEAMID}.loopkit.Loop.LoopWatch.watchkitextension", [
+    configure_bundle_id("WatchApp Extension", "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch.watchkitextension", [
       Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
       Spaceship::ConnectAPI::BundleIdCapability::Type::SIRIKIT
     ])
 
-    configure_bundle_id("Loop Widget Extension", "com.#{TEAMID}.loopkit.Loop.LoopWidgetExtension", [
+    configure_bundle_id("Loop Widget Extension", "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWidgetExtension", [
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
     ])
     
@@ -217,12 +218,12 @@ platform :ios do
       verbose: true,
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
       app_identifier: [
-        "com.#{TEAMID}.loopkit.Loop", 
-        "com.#{TEAMID}.loopkit.Loop.statuswidget", 
-        "com.#{TEAMID}.loopkit.Loop.LoopWatch.watchkitextension", 
-        "com.#{TEAMID}.loopkit.Loop.LoopWatch", 
-        "com.#{TEAMID}.loopkit.Loop.Loop-Intent-Extension",
-        "com.#{TEAMID}.loopkit.Loop.LoopWidgetExtension",
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.statuswidget", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch.watchkitextension", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWatch", 
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.Loop-Intent-Extension",
+        "com.#{TEAMID_SUFFIX}.loopkit.Loop.LoopWidgetExtension",
       ]
     )
   end
@@ -242,7 +243,7 @@ platform :ios do
       bundle_id = Spaceship::ConnectAPI::BundleId.find(identifier)
     end
 
-    find_bundle_id("com.#{TEAMID}.loopkit.Loop")
+    find_bundle_id("com.#{TEAMID_SUFFIX}.loopkit.Loop")
 
     match(
       type: "appstore",
@@ -265,7 +266,7 @@ platform :ios do
     
     match_nuke(
       type: "appstore",
-      team_id: "#{TEAMID}",
+      team_id: "#{TEAMID_SUFFIX}",
       skip_confirmation: true,
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}")
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,7 +12,7 @@
 
 default_platform(:ios)
 
-TEAMID = ENV["TEAMID"]
+TEAMID = ENV["TEAMID_SUFFIX"].to_s.empty? ? "#{ENV["TEAMID"]}" : "#{ENV["TEAMID"]}-#{ENV["TEAMID_SUFFIX"]}"
 GH_PAT = ENV["GH_PAT"]
 GITHUB_WORKSPACE = ENV["GITHUB_WORKSPACE"]
 GITHUB_REPOSITORY_OWNER = ENV["GITHUB_REPOSITORY_OWNER"]
@@ -123,6 +123,7 @@ platform :ios do
       configuration: "Release",
       destination: 'generic/platform=iOS',
       buildlog_path: 'buildlog'
+      xcargs: "MAIN_APP_BUNDLE_IDENTIFIER=com.#{TEAMID}.loopkit.Loop"
     )
 
     copy_artifacts(


### PR DESCRIPTION
This change helps create multiple versions of Loop for distribution.

Steps:

    Create a new fork
    Create a new repository variable called: TEAMID_SUFFIX
    Build normally using GH actions

Impact:
    If TEAMID_SUFFIX variable does NOT exists in the repository, no change to the building steps.
    If TEAMID_SUFFIX variable exists, and is formatted correctly (A-Z, 0-9, 1 to 5 characters long), the new TEAMID will have a format of: TEAMID-SUFFIX (ex. Z7P62XVNWC-ABC12)

Changes:
Add TEAMID_SUFFIX repository variable to allow multiple unique Bundle IDs
Add checks to formatting in Validate_Secrets
Pass xcargs in gym to change MAIN_APP_BUNDLE_IDENTIFIER when a suffix is used.
Append TEAMID_SUFFIX to TEAM_ID variable in fastlane and all GH actions.