### PR TITLE
chore: update checkout and upload-artifact github actions

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -90,7 +90,7 @@ jobs:
         if: |
           steps.workflow-permission.outputs.has_permission == 'true' &&
           (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -178,7 +178,7 @@ jobs:
         run: "sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer"
 
       - name: Checkout Repo for building
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GH_PAT }}
           submodules: recursive
@@ -255,7 +255,7 @@ jobs:
       # Upload Build artifacts
       - name: Upload build log, IPA and Symbol artifacts
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
@@ -98,7 +98,7 @@ jobs:
           run: echo "new_certificate_needed=${{ needs.create_certs.outputs.new_certificate_needed }}"
 
         - name: Checkout repository
-          uses: actions/checkout@v5
+          uses: actions/checkout@v6
 
         - name: Install dependencies
           run: bundle install

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -116,7 +116,7 @@ jobs:
       TEAMID: ${{ secrets.TEAMID }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Project Dependencies
         run: bundle install


### PR DESCRIPTION
Updates checkout and upload-artifact github actions to latest. As of [bafb750](https://github.com/LoopKit/LoopWorkspace/commit/bafb750afa2b14d1a3b06752ab839a2af28c11ff), these actions were bumped to avoid node 24 warnings, and this upgrades again to the latest versions

## validations

Neither GHA has any breaking changes that should affect this repo
- upload-artifact@v7 only has internal breaking changes like changing to ESM
- checkout-action@v6 persists creds to another file

Here are some example runs on my fork
- [Validate secrets](https://github.com/20jasper/LoopWorkspace/actions/runs/24009965040)
- [Add identifiers](https://github.com/20jasper/LoopWorkspace/actions/runs/24009994305)
- [Create Certificates](https://github.com/20jasper/LoopWorkspace/actions/runs/24010011360)
- [build loop](https://github.com/20jasper/LoopWorkspace/actions/runs/24010050102)
