### PR TITLE
Chore/update to fastlane 2.233.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "fastlane", "2.232.1"
+gem "fastlane", "2.233.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gem "fastlane", "2.233.1"
+gem "json", ">=2.19.2"
+gem "addressable", ">=2.9.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,10 +68,11 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.232.1)
+    fastlane (2.233.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -91,7 +92,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       faraday_middleware (~> 1.0)
       fastimage (>= 2.1.0, < 3.0.0)
-      fastlane-sirp (>= 1.0.0)
+      fastlane-sirp (>= 1.1.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
@@ -121,8 +122,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-sirp (1.0.0)
-      sysrandom (~> 1.0)
+    fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.54.0)
       google-apis-core (>= 0.11.0, < 2.a)
@@ -202,7 +202,6 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
-    sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -231,7 +230,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.232.1)
+  fastlane (= 2.233.1)
 
 BUNDLED WITH
   4.0.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)
@@ -166,7 +166,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.18.0)
+    json (2.19.4)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -230,7 +230,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  addressable (>= 2.9.0)
   fastlane (= 2.233.1)
+  json (>= 2.19.2)
 
 BUNDLED WITH
   4.0.6


### PR DESCRIPTION
## Purpose:

Use the most recent version of fastlane, 2.233.1 and address dependabot security issues with the Gemfile.lock file.

✅ This version was successfully tested

## Method

### Update to fastlane 2.233.1

1. Modify Gemfile for fastlane 2.233.1
2. in Terminal, use the command `bundle install`
3. commit the modified Gemfile and Gemfile.lock

### Address security issues

1. Modify Gemfile for to add `gem "json", ">=2.19.2"` and `gem "addressable", ">=2.9.0"`
2. in Terminal, use the command `bundle install`
3. commit the modified Gemfile and Gemfile.lock

## Test

Perform the test after both commits are made.

### Configuration

Do the tests at the docs-test GitHub username, LoopWorkspace fork

* Delete one of the Loop Identifiers (to ensure it will be created again)
   *  delete Loop Intent Extension
* Revoke the Distribution Certificate (to ensure it will be created again)
* set chore/update_to_fastlane_2.233.1 as default branch at docs-test GitHub username

### Test Narrative

✅ [successful Validate Secrets](https://github.com/docs-test/LoopWorkspace/actions/runs/25257318515)
✅ [successful Add Identifiers](https://github.com/docs-test/LoopWorkspace/actions/runs/25257334872)
   * observe the Loop Intent Extension is created
   * add the Loop App group to the newly created Loop Intent Extension
✅ [successful build - which does the nuke/create cert as part of the action](https://github.com/docs-test/LoopWorkspace/actions/runs/25257379032)