### PR TITLE
Update dev to 3.14.2

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -12,11 +12,11 @@ jobs:
   identifiers:
     name: Add Identifiers
     needs: validate
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -90,7 +90,7 @@ jobs:
         if: |
           steps.workflow-permission.outputs.has_permission == 'true' &&
           (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -100,7 +100,7 @@ jobs:
           steps.workflow-permission.outputs.has_permission == 'true' &&
           vars.SCHEDULED_SYNC != 'false' && github.repository_owner != 'LoopKit'
         id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.2
         with:
           target_sync_branch: ${{ env.TARGET_BRANCH }}
           shallow_since: 6 months ago
@@ -165,7 +165,7 @@ jobs:
   build:
     name: Build
     needs: [check_certs, check_status]
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
     if:
@@ -175,10 +175,10 @@ jobs:
         (vars.SCHEDULED_SYNC != 'false' && needs.check_status.outputs.NEW_COMMITS == 'true' )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer"
 
       - name: Checkout Repo for building
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_PAT }}
           submodules: recursive
@@ -255,7 +255,7 @@ jobs:
       # Upload Build artifacts
       - name: Upload build log, IPA and Symbol artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/build_loop.yml
+++ b/.github/workflows/build_loop.yml
@@ -175,7 +175,7 @@ jobs:
         (vars.SCHEDULED_SYNC != 'false' && needs.check_status.outputs.NEW_COMMITS == 'true' )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_26.4.app/Contents/Developer"
 
       - name: Checkout Repo for building
         uses: actions/checkout@v5

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -22,14 +22,14 @@ jobs:
   create_certs:
     name: Certificates
     needs: validate
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       new_certificate_needed: ${{ steps.set_output.outputs.new_certificate_needed }}
   
     steps:
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
@@ -63,7 +63,8 @@ jobs:
         id: set_output
         run: |
           CERT_STATUS_FILE="${{ github.workspace }}/fastlane/new_certificate_needed.txt"
-          ENABLE_NUKE_CERTS=${{ vars.ENABLE_NUKE_CERTS }}
+          ENABLE_NUKE_CERTS=$(echo "${{ vars.ENABLE_NUKE_CERTS }}" | tr '[:upper:]' '[:lower:]')
+          FORCE_NUKE_CERTS=$(echo "${{ vars.FORCE_NUKE_CERTS }}" | tr '[:upper:]' '[:lower:]')
           
           if [ -f "$CERT_STATUS_FILE" ]; then
             CERT_STATUS=$(cat "$CERT_STATUS_FILE" | tr -d '\n' | tr -d '\r') # Read file content and strip newlines
@@ -82,22 +83,22 @@ jobs:
             echo "::error::❌ No valid distribution certificate found. Automated renewal of certificates was skipped because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
             exit 1
           fi
-          # Check if vars.FORCE_NUKE_CERTS is not set to true
-          if [ vars.FORCE_NUKE_CERTS = "true" ]; then
+          # Check if FORCE_NUKE_CERTS is set to true
+          if [ "$FORCE_NUKE_CERTS" = "true" ]; then
             echo "::warning::‼️ Nuking of certificates was forced because the repository variable FORCE_NUKE_CERTS is set to 'true'."
           fi
   # Nuke Certs if needed, and if the repository variable ENABLE_NUKE_CERTS is set to 'true', or if FORCE_NUKE_CERTS is set to 'true', which will always force certs to be nuked
   nuke_certs:
       name: Nuke certificates
       needs: [validate, create_certs]
-      runs-on: macos-15
+      runs-on: macos-26
       if: ${{ (needs.create_certs.outputs.new_certificate_needed == 'true' && vars.ENABLE_NUKE_CERTS == 'true') || vars.FORCE_NUKE_CERTS == 'true' }}
       steps:
         - name: Output from step id 'check_certs'
           run: echo "new_certificate_needed=${{ needs.create_certs.outputs.new_certificate_needed }}"
 
         - name: Checkout repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Install dependencies
           run: bundle install

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -105,7 +105,7 @@ jobs:
   validate-fastlane-secrets:
     name: Fastlane
     needs: [validate-access-token]
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       GH_PAT: ${{ secrets.GH_PAT }}
       GH_TOKEN: ${{ secrets.GH_PAT }}
@@ -116,7 +116,7 @@ jobs:
       TEAMID: ${{ secrets.TEAMID }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Project Dependencies
         run: bundle install

--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "LibreTransmitter"]
 	path = LibreTransmitter
 	url = https://github.com/LoopKit/LibreTransmitter.git
+[submodule "OmnipodKit"]
+	path = OmnipodKit
+	url = https://github.com/loopandlearn/OmnipodKit

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,9 +31,6 @@
 [submodule "LogglyService"]
 	path = LogglyService
 	url = https://github.com/LoopKit/LogglyService.git
-[submodule "OmniBLE"]
-	path = OmniBLE
-	url = https://github.com/LoopKit/OmniBLE.git
 [submodule "NightscoutRemoteCGM"]
 	path = NightscoutRemoteCGM
 	url = https://github.com/LoopKit/NightscoutRemoteCGM.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,9 +46,6 @@
 [submodule "TidepoolService"]
 	path = TidepoolService
 	url = https://github.com/LoopKit/TidepoolService.git
-[submodule "OmniKit"]
-	path = OmniKit
-	url = https://github.com/LoopKit/OmniKit.git
 [submodule "MinimedKit"]
 	path = MinimedKit
 	url = https://github.com/LoopKit/MinimedKit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -61,3 +61,6 @@
 [submodule "OmnipodKit"]
 	path = OmnipodKit
 	url = https://github.com/loopandlearn/OmnipodKit
+[submodule "MedtrumKit"]
+	path = MedtrumKit
+	url = https://github.com/jbr7rr/MedtrumKit

--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "MedtrumKit"]
 	path = MedtrumKit
 	url = https://github.com/jbr7rr/MedtrumKit
+[submodule "EversenseKit"]
+	path = EversenseKit
+	url = https://github.com/bastiaanv/EversenseKit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,137 @@
+# Contributing to Loop
+
+Thank you for your interest in contributing to Loop.
+
+Loop is a community effort, and contributions of all kinds are welcome. This document outlines some guidelines, good practices, and expectations for contributing to the project, with the goal of making collaboration and review as smooth as possible.
+
+Whether you are helping other users, improving documentation, translating the app, testing builds, reviewing code, or contributing new features and fixes, your work matters.
+
+Loop is built using the LoopWorkspace repository. The primary source for the app is at https://github.com/LoopKit/LoopWorkspace.
+
+## Ways to contribute
+
+There are many ways to support the Loop community:
+
+- **Help others** by answering questions and guiding users in support communities.
+- Improve the **documentation** by updating or expanding LoopDocs.
+- Improve the **app** by contributing code, fixes, features, or tests.
+- Help with **translation and localization** through Loop lokalise.
+- Support **testing and feedback** by validating changes and reporting issues clearly.
+
+### Pay it forward
+
+If Loop has helped you manage your diabetes successfully, consider paying it forward by helping others. Answering questions in [Loop Zulipchat](https://loop.zulipchat.com/) or the [Loop and Learn](https://www.facebook.com/groups/LOOPandLEARN) Facebook group can make a real difference for someone getting started.
+
+### Translate
+
+Loop is translated into multiple languages to make it easier to understand and use around the world. Translation for the submodules that make up the Loop app is managed through the [Loop lokalise project](https://loopkit.github.io/loopdocs/faqs/app-translation/#code-translation) and does not require programming experience.
+
+If your preferred language is missing, or you would like to improve an existing translation, please sign up as a translator following the directions in the link above.
+
+### Develop
+
+Do you work with Swift? UI/UX? Testing? API optimization? Data storage?
+
+Loop is a collaborative project, and contributions of all kinds are welcome. Whether you are writing code, improving the user experience, testing builds, helping with documentation, or contributing in other ways, your help matters.
+
+## General principles
+
+- Start small. Smaller, focused contributions are easier to review, test, and merge.
+- For larger changes or new features, open or reference an issue first so there is a clear place for discussion and progress tracking.
+- Reach out early if you are planning to work on something substantial, especially if it may overlap with work already in progress.
+- Keep discussions constructive, respectful, and focused on improving Loop for the community.
+- Remember that Loop is part of a wider open source AID ecosystem. Collaboration and maintainability matter just as much as shipping features.
+
+## Development guidelines
+
+### Coding conventions
+
+- Use Xcode and follow the existing formatting and style used throughout the codebase.
+- Keep indentation and formatting consistent in every file you change.
+- Format your code before committing.
+- Avoid unrelated formatting-only changes in files you are not otherwise modifying.
+- Choose clear, readable code over clever or overly compact solutions.
+- Follow existing naming, file organization, and architectural patterns unless there is a good reason not to.
+
+### Strings and localization
+
+- Add new user-facing strings in the appropriate localization mechanism used by the app.
+- Provide English source strings only unless the contribution is specifically about translations.
+- Translation and localization for other languages should go through the [Loop lokalise project](https://loopkit.github.io/loopdocs/faqs/app-translation/#code-translation).
+
+### Documentation
+
+- Update docstrings when your change affects setup, configuration, behavior, workflows, or troubleshooting.
+- Keep documentation changes clear and practical.
+- ocumentation contributions are just as valuable as code contributions.
+
+## Branches, commits, and pull requests
+
+### Getting started
+
+The example below is for the Loop repository. Similar contributions can be made to other respositories as needed.
+
+1. Fork the `dev` branch of the [Loop repository](https://github.com/LoopKit/Loop) on GitHub.
+1. Create a separate branch for each feature or fix with an [appropriate name](#branch-names).
+1. Branch from the most recent appropriate development branch (typically `dev`).
+1. Commit your changes to your fork.
+1. When ready, open a pull request against the upstream repository (`LoopKit/Loop`).
+
+### Before opening a pull request
+
+- Rebase or otherwise sync your branch with the latest target branch.
+- Make sure your change is focused and does not include unrelated edits.
+- Test your changes as thoroughly as you reasonably can.
+- Update relevant documentation when needed.
+- Double-check for debug code, commented-out code, accidental version changes, or temporary workarounds left behind.
+
+### Pull request guidance
+
+- Keep pull requests as small and focused as practical.
+- Use a clear title and description.
+- Explain **what** changed and **why**.
+- Link the relevant issue when applicable.
+- Mention any areas that need particular review attention.
+- Be open to feedback and follow-up changes during review.
+- Use AI tools, if at all, as a support for small, well-understood tasks rather than to generate large parts of a contribution
+- Do not submit AI-heavy or "vibe-coded" pull requests; we welcome thoughtful use of tooling, but contributions need to be intentionally designed.
+
+## Naming conventions
+
+### Branch names
+
+Use short, descriptive branch names that make the purpose of the change obvious. For example:
+
+- `fix/watchstate-sync`
+- `feature/onboarding-target-behavior`
+- `refactor/therapy-editor`
+
+### Pull request titles
+
+Use concise, descriptive pull request titles. Good titles usually start with the type of change, for example:
+
+- `Fix watch state sync timing issue`
+- `Add onboarding step for target behavior`
+- `Update build documentation`
+
+## Communication and coordination
+
+For new ideas, larger features, or work that may affect multiple parts of the app, **discuss it with the community first** — reach out to the contributor core on [Loop Zulipchat](https://loop.zulipchat.com/). This helps reduce duplicate work, avoid merge conflicts, and improve the final design.
+
+## Review expectations
+
+Please remember that Loop is maintained by contributors with limited time. Reviews may take time, and some pull requests may require iteration before they are ready to merge.
+
+To help keep reviews efficient:
+
+- Keep the scope narrow.
+- Explain your reasoning clearly.
+- Respond to review comments directly.
+- Avoid force-pushing large unexplained rewrites during active review unless necessary.
+- AI-assisted work is welcome for limited, well-understood tasks, but contributions should remain author-driven and must be code you fully understand, and can explain.
+
+We do not accept pull requests that are largely AI-generated or submitted without careful engineering judgment, testing, and alignment with Loop’s existing patterns.
+
+## Final note
+
+Loop exists because people choose to contribute their time, knowledge, and care to a shared effort. Thank you for helping improve the project and support the broader open source AID community.

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "fastlane", "2.232.1"
+gem "fastlane", "2.234.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source "https://rubygems.org"
-gem "fastlane", "2.234.0"
+gem "fastlane", "2.235.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)
@@ -68,17 +68,18 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.4)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.232.1)
-      CFPropertyList (>= 2.3, < 4.0.0)
-      abbrev (~> 0.1.2)
+    fastlane (2.234.0)
+      CFPropertyList (>= 2.3, < 5.0.0)
+      abbrev (~> 0.1)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
       aws-sdk-s3 (~> 1.197)
       babosa (>= 1.0.3, < 2.0.0)
-      base64 (~> 0.2.0)
+      base64 (~> 0.2)
       benchmark (>= 0.1.0)
       bundler (>= 1.17.3, < 5.0.0)
       colored (~> 1.2)
@@ -91,7 +92,7 @@ GEM
       faraday-cookie_jar (~> 0.0.6)
       faraday_middleware (~> 1.0)
       fastimage (>= 2.1.0, < 3.0.0)
-      fastlane-sirp (>= 1.0.0)
+      fastlane-sirp (>= 1.1.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
@@ -104,9 +105,9 @@ GEM
       logger (>= 1.6, < 2.0)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)
-      mutex_m (~> 0.3.0)
+      mutex_m (~> 0.3)
       naturally (~> 2.2)
-      nkf (~> 0.2.0)
+      nkf (~> 0.2)
       optparse (>= 0.1.1, < 1.0.0)
       ostruct (>= 0.1.0)
       plist (>= 3.1.0, < 4.0.0)
@@ -121,8 +122,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-sirp (1.0.0)
-      sysrandom (~> 1.0)
+    fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.54.0)
       google-apis-core (>= 0.11.0, < 2.a)
@@ -166,7 +166,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.18.0)
+    json (2.19.4)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -202,7 +202,6 @@ GEM
     simctl (1.6.10)
       CFPropertyList
       naturally
-    sysrandom (1.0.5)
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -231,7 +230,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.232.1)
+  fastlane (= 2.234.0)
 
 BUNDLED WITH
   4.0.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.234.0)
+    fastlane (2.235.0)
       CFPropertyList (>= 2.3, < 5.0.0)
       abbrev (~> 0.1)
       addressable (>= 2.8, < 3.0.0)
@@ -81,7 +81,7 @@ GEM
       babosa (>= 1.0.3, < 2.0.0)
       base64 (~> 0.2)
       benchmark (>= 0.1.0)
-      bundler (>= 1.17.3, < 5.0.0)
+      bundler (>= 2.4.0, < 5.0.0)
       colored (~> 1.2)
       commander (~> 4.6)
       csv (~> 3.3)
@@ -96,12 +96,12 @@ GEM
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-apis-androidpublisher_v3 (~> 0.3)
       google-apis-playcustomapp_v1 (~> 0.1)
-      google-cloud-env (>= 1.6.0, <= 2.1.1)
+      google-cloud-env (>= 1.6.0, < 2.3.0)
       google-cloud-storage (~> 1.31)
       highline (~> 2.0)
       http-cookie (~> 1.0.5)
       json (< 3.0.0)
-      jwt (>= 2.1.0, < 3)
+      jwt (>= 2.1.0, < 4)
       logger (>= 1.6, < 2.0)
       mini_magick (>= 4.9.4, < 5.0.0)
       multipart-post (>= 2.0.0, < 3.0.0)
@@ -230,7 +230,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane (= 2.234.0)
+  fastlane (= 2.235.0)
 
 BUNDLED WITH
-  4.0.6
+  4.0.12

--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
@@ -121,6 +121,9 @@
       location = "group:MinimedKit/MinimedKit.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:OmnipodKit/OmnipodKit.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:G7SensorKit/G7SensorKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
@@ -124,6 +124,9 @@
       location = "group:OmnipodKit/OmnipodKit.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:MedtrumKit/MedtrumKit.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:G7SensorKit/G7SensorKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
@@ -109,9 +109,6 @@
       location = "group:TrueTime.swift/TrueTime.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:OmniBLE/OmniBLE.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:RileyLinkKit/RileyLinkKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
@@ -112,9 +112,6 @@
       location = "group:OmniBLE/OmniBLE.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:OmniKit/OmniKit.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:RileyLinkKit/RileyLinkKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
@@ -127,6 +127,9 @@
       location = "group:MedtrumKit/MedtrumKit.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:EversenseKit/EversenseKit.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:G7SensorKit/G7SensorKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -154,6 +154,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D889B2382D2B4BFE00C8E64C"
+               BuildableName = "OmnipodKitPlugin.loopplugin"
+               BlueprintName = "OmnipodKitPlugin"
+               ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C124021629C7D93D00B32844"
                BuildableName = "OmniKitPlugin.loopplugin"
                BlueprintName = "OmniKitPlugin"
@@ -537,6 +551,16 @@
                BuildableName = "RileyLinkBLEKitTests.xctest"
                BlueprintName = "RileyLinkBLEKitTests"
                ReferencedContainer = "container:RileyLinkKit/RileyLinkKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D8D0ED172D74EF41000B0AF4"
+               BuildableName = "OmniTests.xctest"
+               BlueprintName = "OmniTests"
+               ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -140,6 +140,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E767D422D67B790004B1971"
+               BuildableName = "MedtrumKitPlugin.loopplugin"
+               BlueprintName = "MedtrumKitPlugin"
+               ReferencedContainer = "container:MedtrumKit/MedtrumKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C1E34B5A29C7AD01009A50A5"
                BuildableName = "MinimedKitPlugin.loopplugin"
                BlueprintName = "MinimedKitPlugin"

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -182,20 +182,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C187C196279086A8006E3557"
-               BuildableName = "OmniBLEPlugin.loopplugin"
-               BlueprintName = "OmniBLEPlugin"
-               ReferencedContainer = "container:OmniBLE/OmniBLE.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "B40BF25D23ABD47400A43CEE"
                BuildableName = "ShareClientPlugin.loopplugin"
                BlueprintName = "ShareClientPlugin"
@@ -406,20 +392,6 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "84752E8A26ED0FFE009FD801"
-               BuildableName = "OmniBLETests.xctest"
-               BlueprintName = "OmniBLETests"
-               ReferencedContainer = "container:OmniBLE/OmniBLE.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "A91BAC2322BC691A00ABF1BB"
                BuildableName = "NightscoutServiceKitTests.xctest"
                BlueprintName = "NightscoutServiceKitTests"
@@ -495,16 +467,6 @@
                BuildableName = "LoopKitHostedTests.xctest"
                BlueprintName = "LoopKitHostedTests"
                ReferencedContainer = "container:LoopKit/LoopKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "84752E8A26ED0FFE009FD801"
-               BuildableName = "OmniBLETests.xctest"
-               BlueprintName = "OmniBLETests"
-               ReferencedContainer = "container:OmniBLE/OmniBLE.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -294,6 +294,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3E6696E52E927EB900AAE4F1"
+               BuildableName = "EversenseKitPlugin.loopplugin"
+               BlueprintName = "EversenseKitPlugin"
+               ReferencedContainer = "container:EversenseKit/EversenseKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C17F511C291EACCD00555EB5"
                BuildableName = "G7SensorPlugin.loopplugin"
                BlueprintName = "G7SensorPlugin"

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -577,6 +577,16 @@
                ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B7D3A8D92C148CC4002EE003"
+               BuildableName = "MedtrumKitTests.xctest"
+               BlueprintName = "MedtrumKitTests"
+               ReferencedContainer = "container:MedtrumKit/MedtrumKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -182,20 +182,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C124021629C7D93D00B32844"
-               BuildableName = "OmniKitPlugin.loopplugin"
-               BlueprintName = "OmniKitPlugin"
-               ReferencedContainer = "container:OmniKit/OmniKit.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C187C196279086A8006E3557"
                BuildableName = "OmniBLEPlugin.loopplugin"
                BlueprintName = "OmniBLEPlugin"
@@ -559,16 +545,6 @@
                BuildableName = "MinimedKitTests.xctest"
                BlueprintName = "MinimedKitTests"
                ReferencedContainer = "container:MinimedKit/MinimedKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C12ED9C929C7DBA900435701"
-               BuildableName = "OmniKitTests.xctest"
-               BlueprintName = "OmniKitTests"
-               ReferencedContainer = "container:OmniKit/OmniKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -601,16 +601,6 @@
                ReferencedContainer = "container:MedtrumKit/MedtrumKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3EFE70822E08434B00CF6B9E"
-               BuildableName = "EversenseKitTests.xctest"
-               BlueprintName = "EversenseKitTests"
-               ReferencedContainer = "container:EversenseKit/EversenseKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -601,6 +601,16 @@
                ReferencedContainer = "container:MedtrumKit/MedtrumKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3EFE70822E08434B00CF6B9E"
+               BuildableName = "EversenseKitTests.xctest"
+               BlueprintName = "EversenseKitTests"
+               ReferencedContainer = "container:EversenseKit/EversenseKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Scripts/LocalizationInstructions.md
+++ b/Scripts/LocalizationInstructions.md
@@ -19,9 +19,20 @@ Table of Contents:
     * [Prepare xliff_out folder](#prepare-xliff_out-folder)
     * [Update lokalise strings](#update-lokalise-strings)
 * [Utility Scripts](#utility-scripts)
+    * [Additional Utility Scripts](#additional-utility-scripts)
 * [Questions and notes](#questions-and-notes)
 
 ## Overview
+
+> The translations for these repositories are added to lokalise
+> * DanaKit
+> * EversenseKit
+> * MedtrumKit
+> * OmnipodKit
+
+> In order to manage those localization strings, the translation work will be done in the feat/all-managers branch, which includes all repositories.
+
+> The Scripts needed to handle these new repositories are found on in this branch (for now).
 
 Translations for Loop are performed by volunteers at [lokalise](https://app.lokalise.com/projects). 
 Several scripts were added to assist in bringing those translations into the repositories and updating keys when strings are added or modified.
@@ -304,6 +315,42 @@ The define_common.sh is used by other scripts to provide a single source for the
 * PROJECTS (all the submodules for LoopWorkspace to localize with owners and branches)
 
 If you need to start over but don't want to lose prior work, use archive_translations.sh. However, this is probably no longer necessary with the optional arguments available with the manual scripts.
+
+### Additional Utility Scripts
+
+These scripts, currently found in feat/all-managers, are used for several purposes but are not part of the Localization process.
+
+They are documented here for convenience. The alphabetic list is provided here.
+
+* open_selected_url.sh
+* reconfigure_remotes.sh
+* update_loopandlearn_forks.sh
+* update_submodule_refs.sh
+
+#### update_submodules_refs
+
+This is used to checkout the most recent branch for each submodule in the workspace.  It is used as a final step after the translation is completed but also is used to bring in other updates from the submodules into the workspace.
+
+After running this script, use `git status` to determine which submodules were updated so the modifications can be tested and committed.
+
+#### reconfigure_remotes
+
+This is a helper script for a LoopWorkspace clone for use when the .gitmodules path name changes for any reason, and the local clone needs to be updated.
+
+This change was made because (2026 April 30) the translation work for feature branches and the submodule update work were using different paths and it was just too confusing and error prone. By using the upstream fork in .gitmodules and in the translations scripts, life is simpler.
+
+* The path for DanaKit, EversenseKit and MedtrumKit was changed from loopandlearn to the respective upstream repositories
+* If a local clone has any submodules pointing to loopandlearn as the remote named `origin`, run this script to update it
+
+There is no harm running the script even if all submodules are properly configured.
+
+### Trio Utility Scripts
+
+These are Trio support utilities run within a LoopWorkspace clone to sync the loopandlearn forks for use with Trio. They require appropriate permissions.
+
+We support Trio with some of the submodules. To enable Trio to use a slightly modified version of the repositories, Trio uses loopandlearn, not the upstream repos in their `.gitmodule` list. In order to keep the loopandlearn forks up to date, the `update_loopandlearn_forks.sh` automatically updates all the submodules used by Trio so that loopandlearn forks match the upstream forks for the appropriate branches.
+
+When there are submodules where Trio uses a slightly different version of code, a `trio` branch is created. In that case, the update is done manually. To assist in the process, the script `open_selected_url.sh` is called from within the `update_loopandlearn_forks.sh` script.
 
 ## Questions and notes
 

--- a/Scripts/define_common.sh
+++ b/Scripts/define_common.sh
@@ -74,8 +74,6 @@ PROJECTS=( \
     LoopKit:MinimedKit:main \
     LoopKit:NightscoutRemoteCGM:dev \
     LoopKit:NightscoutService:dev \
-    LoopKit:OmniBLE:dev \
-    LoopKit:OmniKit:main \
     LoopKit:RileyLinkKit:dev \
     LoopKit:TidepoolService:dev \
     loopandlearn:OmnipodKit:main \

--- a/Scripts/define_common.sh
+++ b/Scripts/define_common.sh
@@ -79,6 +79,8 @@ PROJECTS=( \
     LoopKit:RileyLinkKit:dev \
     LoopKit:TidepoolService:dev \
     loopandlearn:OmnipodKit:main \
+    bastiaanv:EversenseKit:dev \
+    jbr7rr:MedtrumKit:dev \
 )
 
 function section_divider() {

--- a/Scripts/define_common.sh
+++ b/Scripts/define_common.sh
@@ -34,7 +34,6 @@ MESSAGE_FILE="xlate_message_file.txt"
 # matches lokalise order, en plus alphabetical order by language name in English
 LANGUAGES=(en \
     ar \
-    ce \
     zh-Hans \
     cs \
     da \
@@ -43,10 +42,10 @@ LANGUAGES=(en \
     fr \
     de \
     he \
-    hi \
     hu \
     it \
     ja \
+    ko \
     nb \
     pl \
     pt-BR \
@@ -79,6 +78,7 @@ PROJECTS=( \
     LoopKit:OmniKit:main \
     LoopKit:RileyLinkKit:dev \
     LoopKit:TidepoolService:dev \
+    loopandlearn:OmnipodKit:main \
 )
 
 function section_divider() {

--- a/Scripts/manual_upload_to_lokalise.sh
+++ b/Scripts/manual_upload_to_lokalise.sh
@@ -37,18 +37,21 @@ foreach lang in $LANGUAGES
 # modify the hyphen to underscore to support lokalise lang-iso expectation
 lang_iso=$(sed "s/zh-Hans/zh_Hans/g; s/pt-BR/pt_BR/g" <<<"$lang")
 
-# flags to consider (neither in use by default)
-#   cleanup-mode (was default) - this deleted any keys in localise not in clone
-#      remove this because we have 3 repos that are work in progress
-#   replace-modified (was not there) - given that we may have input from crowdin,
-#      we may need to use this to update to lokalise, but not sure how to handle this
+# flags updated to default 2026-03-31
+#   cleanup-mode - this deletes any keys in lokalise not in clone;
+#      make sure the appropriate branch, with any new managers is used
+#   replace-modified - this allows us to accept translations from other sources
+#      make sure that if there is new input, it is uploaded promptly to avoid
+#        overwriting what translators provide in lokalise
 lokalise2 \
     --token $LOKALISE_TOKEN \
     --convert-placeholders=false \
     --project-id 414338966417c70d7055e2.75119857 \
     file upload \
     --file ${lang}.xliff \
-    --lang-iso ${lang_iso}
+    --lang-iso ${lang_iso} \
+    --replace-modified \
+    --cleanup-mode
 end
 
 section_divider

--- a/Scripts/update_submodule_refs.sh
+++ b/Scripts/update_submodule_refs.sh
@@ -2,13 +2,24 @@
 
 source Scripts/define_common.sh
 
+section_divider
+echo "You are running ${0}"
+echo
+echo "  This modifies your local clone, in whatever branch is currently selected,"
+echo "  so that every submodule is at the tip of the appropriate branch."
+echo
+current_branch=$(git branch --show-current 2>/dev/null)
+echo "  The current LoopWorkspace branch is $current_branch"
+
+continue_or_quit ${0}
+
 for project in ${PROJECTS}; do
+  echo
   echo "Updating to $project"
   IFS=":" read user dir branch <<< "$project"
   echo "Updating to $branch on $user/$project"
   cd $dir
   git checkout $branch
-  #git branch -D tidepool-sync
   git pull
   cd -
 done

--- a/VersionOverride.xcconfig
+++ b/VersionOverride.xcconfig
@@ -8,5 +8,5 @@
 
 // Version [for DIY Loop]
 //   configure the version number in LoopWorkspace
-LOOP_MARKETING_VERSION = 3.12.0
+LOOP_MARKETING_VERSION = 3.12.1
 CURRENT_PROJECT_VERSION = 57

--- a/VersionOverride.xcconfig
+++ b/VersionOverride.xcconfig
@@ -8,5 +8,5 @@
 
 // Version [for DIY Loop]
 //   configure the version number in LoopWorkspace
-LOOP_MARKETING_VERSION = 3.12.1
+LOOP_MARKETING_VERSION = 3.14.0
 CURRENT_PROJECT_VERSION = 57

--- a/VersionOverride.xcconfig
+++ b/VersionOverride.xcconfig
@@ -8,5 +8,5 @@
 
 // Version [for DIY Loop]
 //   configure the version number in LoopWorkspace
-LOOP_MARKETING_VERSION = 3.13.1
+LOOP_MARKETING_VERSION = 3.12.1
 CURRENT_PROJECT_VERSION = 57

--- a/VersionOverride.xcconfig
+++ b/VersionOverride.xcconfig
@@ -8,5 +8,5 @@
 
 // Version [for DIY Loop]
 //   configure the version number in LoopWorkspace
-LOOP_MARKETING_VERSION = 3.14.1
+LOOP_MARKETING_VERSION = 3.14.2
 CURRENT_PROJECT_VERSION = 57


### PR DESCRIPTION
## Purpose: Prepare for updating dev to version 3.14.2 

With this PR, we are preparing for the next update to dev. The plan is this PR, when merged, will be followed shortly thereafter with a release to main using the same version number.

**HIghlights**
* Add Medtrum as a supported pump
* Add Eversense as a supported CGM
* Add the universal Omnipod Controller, OmnipodKit, and remove the older controllers (OmniKit and OminBLE)

## Method

Collect updates to `dev` branch in this `update_dev_to_3.14.2` branch
* When ready and approved, this PR will be merged into `dev` as version 3.14.2

The `Details` section of this PR will be updated with each commit added to this PR. Before each commit is pushed, the build is tested locally with Xcode and Browser Build.

## Details

* Bump version to 3.14.2
* update Loop: support OmnipodKit, see Loop PR 2426 [Support use of OmnipodKit](https://github.com/LoopKit/Loop/pull/2426)
* updated OmniBLE: fix identifier for 17e for Pod Keep Alive, see OmniBLE PR 170 [fix: Apple model identifier for 17e is now correct](https://github.com/LoopKit/OmniBLE/pull/170)
* update GitHub action to use Xcode 26.4
* update to fastlane 2.335.0
* add submodule OmnipodKit (see notes below)
* add submodule MedtrumKit
* add submodule EversenseKit
* remove submodule OmniKit (replaced with OmnipodKit)
* remove submodule OmniBLE (replaced with OmnipodKit)
* two commits to update Scripts to work with current repositories in v3.14.2

WARNING - ⚠️ Pod users with v3.14.2 will need to stick with v3.14.2 or newer once they build this version where OmnipodKit replaces the older Pod controllers

## OmnipodKit

### What
Adds OmnipodKit as a new submodule and removes the older OmniKit (Eros only) and OmniBLE (DASH only) controllers
* OmnipodKit is the unified Omnipod driver that handles both Eros and DASH pods through one pump manager, and replaces both OmniKit (Eros) and OmniBLE (DASH)
* Users will notice a number of UI/UX updates in OmnipodKit

### Why
Pod-type fragmentation across two separate pump managers means duplicated DIY maintenance work (two trees of fixes, two compatibility matrices, two telemetry profiles). OmnipodKit consolidates the protocols into a single codebase.

### As a Pod users - what do I need to do

Active-pod states from the old managers are automatically migrated to the new OmnipodKit manager
- Pod users should notice some layout and wording difference
- New Pod users have to choose `All Omnipod Types` to use Pods and then after onboarding will see a screen asking the Pod Type: Classic (Eros) or DASH
- ⚠️ Once you build v3.14.2 or later, you cannot return to 3.14.1 or earlier without discarding your active Pod
