### PR TITLE
add OmnipodKit submodule to the next-dev branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -61,3 +61,6 @@
 [submodule "LoopAlgorithm"]
 	path = LoopAlgorithm
 	url = https://github.com/LoopKit/LoopAlgorithm.git
+[submodule "OmnipodKit"]
+	path = OmnipodKit
+	url = https://github.com/loopandlearn/OmnipodKit

--- a/LoopWorkspace.xcworkspace/contents.xcworkspacedata
+++ b/LoopWorkspace.xcworkspace/contents.xcworkspacedata
@@ -124,6 +124,9 @@
       location = "group:MinimedKit/MinimedKit.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:OmnipodKit/OmnipodKit.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:G7SensorKit/G7SensorKit.xcodeproj">
    </FileRef>
    <FileRef

--- a/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
+++ b/LoopWorkspace.xcworkspace/xcshareddata/xcschemes/LoopWorkspace.xcscheme
@@ -154,6 +154,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D889B2382D2B4BFE00C8E64C"
+               BuildableName = "OmnipodKitPlugin.loopplugin"
+               BlueprintName = "OmnipodKitPlugin"
+               ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C124021629C7D93D00B32844"
                BuildableName = "OmniKitPlugin.loopplugin"
                BlueprintName = "OmniKitPlugin"
@@ -537,6 +551,16 @@
                BuildableName = "RileyLinkBLEKitTests.xctest"
                BlueprintName = "RileyLinkBLEKitTests"
                ReferencedContainer = "container:RileyLinkKit/RileyLinkKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D8D0ED172D74EF41000B0AF4"
+               BuildableName = "OmniTests.xctest"
+               BlueprintName = "OmniTests"
+               ReferencedContainer = "container:OmnipodKit/OmnipodKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>


### PR DESCRIPTION
## Purpose

Include OmnipodKit as a pump manager for the next-dev branch.

* The enables people using v3.14.2 to build next-dev on their phones without losing access to an active Pod.

## Method

Created a new branch at loopandlearn OmnipodKit called loop-next-dev with the appropriate changes to the main branch to be compatible with next-dev

Using that branch, followed the instructions to add OmnipodKit to Loop found in the patches folder of OmnipodKit

## Test

Built to a simulator successfully and selected All Omnipod Types as the pump.
