### PR TITLE
Mark scheduled runs with nothing to build as cancelled instead of successful

### DIFF
--- a/.github/workflows/build_loop_auto.yml
+++ b/.github/workflows/build_loop_auto.yml
@@ -148,6 +148,30 @@ jobs:
             echo "is_second_instance=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # When a scheduled run finds nothing new to build, cancel the run so it shows
+  # as "cancelled" instead of "success" — a green check should always mean a
+  # new build was made.
+  cancel_when_no_build:
+    needs: check_status
+    name: Cancel run when there is nothing to build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    if: |
+      github.event_name == 'schedule' &&
+        !(vars.SCHEDULED_BUILD != 'false' && needs.check_status.outputs.IS_SECOND_IN_MONTH == 'true') &&
+        !(vars.SCHEDULED_SYNC != 'false' && needs.check_status.outputs.NEW_COMMITS == 'true')
+    steps:
+      - name: Cancel the run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Repository is up to date and no monthly build is due — cancelling this run so it is not reported as a successful build." >> "$GITHUB_STEP_SUMMARY"
+          gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+          # Keep the job alive until the cancellation lands, so the run ends as
+          # "cancelled" rather than completing successfully first.
+          sleep 300
+
   # Checks if Distribution certificate is present and valid, optionally nukes and
   # creates new certs if the repository variable ENABLE_NUKE_CERTS == 'true'
   # only run if a build is planned

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -12,7 +12,7 @@ These instructions allow you to build your app without having access to a Mac.
 > The browser build **defaults to** automatically updating and building a new version of Loop according to this schedule:
 > - automatically checks for updates weekly and if updates are found, it will build a new version of the app
 >   - even when there are no updates, it builds on the second Sunday of the month
-> - with each scheduled weekly run, a successful build log appears - if the time is very short, it did not need to build - only the long actions (>20 minutes) built a new app
+> - if a scheduled run finds nothing new to build, the run is cancelled and shows as cancelled (grey) in the Actions list - a green check always means a new build was made and uploaded to TestFlight
 > 
 > The [**Optional**](#optional) section provides instructions to modify the default behavior if desired. 
 


### PR DESCRIPTION
## Problem

The scheduled weekly run checks for new commits and only builds when something changed (or when the monthly forced build is due). When there is nothing to build, the build jobs are skipped and the run still completes with a green check — indistinguishable at a glance from a successful build. Users who rely on the green status can believe they have a fresh build even when their last real build attempt failed.

## Change

Copied the change from [LoopFollow PR 705](https://github.com/loopandlearn/LoopFollow/pull/705). See that PR for more information.

Status semantics after this change:

* green — a new build was made and uploaded to TestFlight
* cancelled (grey) — the repository was already up to date, nothing was built
* red — a build was attempted and failed
