### PR TITLE
Localization scripts: use shared PROJECTS list, pin an iOS destination

### DIFF
--- a/Scripts/export_localizations.sh
+++ b/Scripts/export_localizations.sh
@@ -10,7 +10,7 @@ LANGUAGES=(ar cs ru en zh-Hans nl fr de it nb pl es ja pt-BR vi da sv fi ro tr h
 argstring="${LANGUAGES[@]/#/-exportLanguage }"
 IFS=" "; args=( $=argstring )
 
-xcodebuild -scheme LoopWorkspace -exportLocalizations -localizationPath xclocs $args
+xcodebuild -scheme LoopWorkspace -destination 'generic/platform=iOS' -exportLocalizations -localizationPath xclocs $args
 
 mkdir -p xliff_out
 find xclocs -name '*.xliff' -exec cp {} xliff_out \;

--- a/Scripts/import_localizations.sh
+++ b/Scripts/import_localizations.sh
@@ -27,7 +27,11 @@ lokalise2 \
     --replace-breaks=false \
     --unzip-to ./xliff_in
 
-PROJECTS=(LoopKit:AmplitudeService:dev LoopKit:CGMBLEKit:dev LoopKit:G7SensorKit:main LoopKit:LogglyService:dev LoopKit:Loop:dev LoopKit:LoopKit:dev LoopKit:LoopOnboarding:dev LoopKit:LoopSupport:dev LoopKit:NightscoutRemoteCGM:dev LoopKit:NightscoutService:dev LoopKit:OmniBLE:dev LoopKit:TidepoolService:dev LoopKit:dexcom-share-client-swift:dev LoopKit:RileyLinkKit:dev LoopKit:OmniKit:main LoopKit:MinimedKit:main LoopKit:LibreTransmitter:main)
+# PROJECTS (and LANGUAGES) are defined in one place so this list cannot drift again.
+# The copy that used to live here still named OmniBLE and OmniKit, which have not been
+# submodules since they were replaced by OmnipodKit -- with `set -e`, `cd OmniBLE` aborted
+# this script outright.
+source Scripts/define_common.sh
 
 for project in ${PROJECTS}; do
   echo "Prepping $project"
@@ -42,12 +46,12 @@ for project in ${PROJECTS}; do
 done
 
 # Build Loop
-set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' build | xcpretty
+set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' -destination 'generic/platform=iOS' build | xcpretty
 
 
 # Apply translations
 foreach file in xliff_in/*.xliff
-  xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -importLocalizations -localizationPath $file
+  xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -destination 'generic/platform=iOS' -importLocalizations -localizationPath $file
 end
 
 

--- a/Scripts/manual_export_localizations.sh
+++ b/Scripts/manual_export_localizations.sh
@@ -13,7 +13,7 @@ source Scripts/define_common.sh
 argstring="${LANGUAGES[@]/#/-exportLanguage }"
 IFS=" "; args=( $=argstring )
 
-xcodebuild -scheme LoopWorkspace -exportLocalizations -localizationPath xclocs $args
+xcodebuild -scheme LoopWorkspace -destination 'generic/platform=iOS' -exportLocalizations -localizationPath xclocs $args
 
 mkdir -p xliff_out
 find xclocs -name '*.xliff' -exec cp {} xliff_out \;

--- a/Scripts/manual_import_localizations.sh
+++ b/Scripts/manual_import_localizations.sh
@@ -60,14 +60,14 @@ for project in ${PROJECTS}; do
 done
 
 # Build Loop
-set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' build | xcpretty
+set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' -destination 'generic/platform=iOS' build | xcpretty
 
 # Apply translations
 foreach file in xliff_in/*.xliff
   section_divider
   echo " importing ${file}"
   section_divider
-  /usr/bin/time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -importLocalizations -localizationPath $file
+  /usr/bin/time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -destination 'generic/platform=iOS' -importLocalizations -localizationPath $file
 end
 
 section_divider


### PR DESCRIPTION
Opened as a **draft** so CODEOWNERS isn't pinged — mark ready when you want reviewers.

Found while looking into a translator's Xcode 27 beta failure. **It does not explain that failure** (see the last section), but it's a real bug on its own.

## The stale duplicate list

`Scripts/import_localizations.sh` carried its own copy of `PROJECTS`, separate from the maintained list in `Scripts/define_common.sh` that ten other scripts already `source`. The copy had drifted badly:

- Still names **`OmniBLE`** and **`OmniKit`** — neither has been a submodule since `OmnipodKit` replaced them
- Missing **`OmnipodKit`**, **`EversenseKit`**, **`MedtrumKit`** entirely

The script runs under `set -e`, so `cd OmniBLE` aborts it outright. Had it continued, translations for the three missing repos would never have been imported.

The maintained list also targets the correct upstream repos for the PRs it opens — `loopandlearn:OmnipodKit`, `bastiaanv:EversenseKit`, `jbr7rr:MedtrumKit` — rather than the LoopKit forks the stale copy would have used.

Fix: source `define_common.sh` rather than duplicating, so the list has one home and can't drift again.

## Explicit iOS destination

All four localization scripts invoked `xcodebuild` with **no `-destination`**, unlike `.circleci/config.yml` and `AGENTS.md`, which both pass one. That leaves xcodebuild free to resolve destinations across platforms.

Added `-destination 'generic/platform=iOS'` to the build, export and import invocations. It cannot resolve to macOS, and doesn't depend on a particular simulator existing on the machine.

## Verification

- All four scripts pass `zsh -n`
- The sourced `PROJECTS` list expands to the 18 correct entries
- LoopWorkspace builds with the new flag under **Xcode 26.6** and the **Xcode 27.0 beta** (`27A5237l`): `** BUILD SUCCEEDED **`, exit 0

## What this does *not* fix

A translator reported `MACOSX_DEPLOYMENT_TARGET is set to 10.15` errors against five LoopKit targets under Xcode 27 beta 6. **I could not reproduce that**, on either lineage, with their exact destination-less command:

| Branch | Xcode 27.0 beta result |
|---|---|
| `next-dev` | `** BUILD SUCCEEDED **`, zero MACOSX errors |
| `dev` | `** BUILD SUCCEEDED **`, zero MACOSX errors |

`LoopKit.xcodeproj` has never set `MACOSX_DEPLOYMENT_TARGET` on any branch (`git log -S` confirms), and under Xcode 26 those targets resolve it to `26.5` from the SDK. Note also that `CGMBLEKit` and `LibreTransmitter` *do* hardcode `10.15`, and were present in both builds that succeeded — so that value alone isn't fatal to Xcode 27.

The destination flag here is defensible hygiene and may well sidestep it, but I have no evidence it's the cause, and this PR shouldn't be treated as closing that report.

## Not addressed

`MixpanelService` and `LibreLoop` both contain localizable resources but appear in no PROJECTS list. Adding them would change where translation PRs get opened, so I left it alone — worth a separate decision.

Also, `dev` carries the identical stale script and needs the same fix.