### PR TITLE
Localization scripts: use shared PROJECTS list, pin an iOS destination (dev)

### DIFF
--- a/Scripts/export_localizations.sh
+++ b/Scripts/export_localizations.sh
@@ -10,7 +10,7 @@ LANGUAGES=(ar cs ru en zh-Hans nl fr de it nb pl es ja pt-BR vi da sv fi ro tr h
 argstring="${LANGUAGES[@]/#/-exportLanguage }"
 IFS=" "; args=( $=argstring )
 
-xcodebuild -scheme LoopWorkspace -exportLocalizations -localizationPath xclocs $args
+xcodebuild -scheme LoopWorkspace -destination 'generic/platform=iOS' -exportLocalizations -localizationPath xclocs $args
 
 mkdir -p xliff_out
 find xclocs -name '*.xliff' -exec cp {} xliff_out \;

--- a/Scripts/import_localizations.sh
+++ b/Scripts/import_localizations.sh
@@ -27,7 +27,11 @@ lokalise2 \
     --replace-breaks=false \
     --unzip-to ./xliff_in
 
-PROJECTS=(LoopKit:AmplitudeService:dev LoopKit:CGMBLEKit:dev LoopKit:G7SensorKit:main LoopKit:LogglyService:dev LoopKit:Loop:dev LoopKit:LoopKit:dev LoopKit:LoopOnboarding:dev LoopKit:LoopSupport:dev LoopKit:NightscoutRemoteCGM:dev LoopKit:NightscoutService:dev LoopKit:OmniBLE:dev LoopKit:TidepoolService:dev LoopKit:dexcom-share-client-swift:dev LoopKit:RileyLinkKit:dev LoopKit:OmniKit:main LoopKit:MinimedKit:main LoopKit:LibreTransmitter:main)
+# PROJECTS (and LANGUAGES) are defined in one place so this list cannot drift again.
+# The copy that used to live here still named OmniBLE and OmniKit, which have not been
+# submodules since they were replaced by OmnipodKit -- with `set -e`, `cd OmniBLE` aborted
+# this script outright.
+source Scripts/define_common.sh
 
 for project in ${PROJECTS}; do
   echo "Prepping $project"
@@ -42,12 +46,12 @@ for project in ${PROJECTS}; do
 done
 
 # Build Loop
-set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' build | xcpretty
+set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' -destination 'generic/platform=iOS' build | xcpretty
 
 
 # Apply translations
 foreach file in xliff_in/*.xliff
-  xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -importLocalizations -localizationPath $file
+  xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -destination 'generic/platform=iOS' -importLocalizations -localizationPath $file
 end
 
 

--- a/Scripts/manual_export_localizations.sh
+++ b/Scripts/manual_export_localizations.sh
@@ -13,7 +13,7 @@ source Scripts/define_common.sh
 argstring="${LANGUAGES[@]/#/-exportLanguage }"
 IFS=" "; args=( $=argstring )
 
-xcodebuild -scheme LoopWorkspace -exportLocalizations -localizationPath xclocs $args
+xcodebuild -scheme LoopWorkspace -destination 'generic/platform=iOS' -exportLocalizations -localizationPath xclocs $args
 
 mkdir -p xliff_out
 find xclocs -name '*.xliff' -exec cp {} xliff_out \;

--- a/Scripts/manual_import_localizations.sh
+++ b/Scripts/manual_import_localizations.sh
@@ -60,14 +60,14 @@ for project in ${PROJECTS}; do
 done
 
 # Build Loop
-set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' build | xcpretty
+set -o pipefail && time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme 'LoopWorkspace' -destination 'generic/platform=iOS' build | xcpretty
 
 # Apply translations
 foreach file in xliff_in/*.xliff
   section_divider
   echo " importing ${file}"
   section_divider
-  /usr/bin/time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -importLocalizations -localizationPath $file
+  /usr/bin/time xcodebuild -workspace LoopWorkspace.xcworkspace -scheme "LoopWorkspace" -destination 'generic/platform=iOS' -importLocalizations -localizationPath $file
 end
 
 section_divider


### PR DESCRIPTION
Opened as a **draft** so CODEOWNERS isn't pinged — mark ready when you want reviewers.

Targets `dev`, the branch a translator was building when they hit Xcode 27 beta errors. The four scripts are byte-identical between `dev` and `next-dev`, and `dev` already carries the same current `define_common.sh`, so this applies cleanly.

## The stale duplicate list

`Scripts/import_localizations.sh` kept its own copy of `PROJECTS` rather than sourcing `Scripts/define_common.sh`, which ten other scripts already use. That copy had drifted badly:

- Still names **`OmniBLE`** and **`OmniKit`** — neither has been a submodule since `OmnipodKit` replaced them
- Missing **`OmnipodKit`**, **`EversenseKit`**, **`MedtrumKit`** entirely

The script runs under `set -e`, so `cd OmniBLE` aborts it outright. Had it continued, translations for those three repos would never have been imported.

The maintained list also targets the correct upstream repos for the PRs the script opens — `loopandlearn:OmnipodKit`, `bastiaanv:EversenseKit`, `jbr7rr:MedtrumKit` — rather than the LoopKit forks the stale copy implied.

Fix: source `define_common.sh` instead of duplicating, so the list has one home and can't drift again.

## Explicit iOS destination

All four localization scripts called `xcodebuild` with **no `-destination`**, unlike `.circleci/config.yml` and `AGENTS.md`, which both pass one — leaving xcodebuild free to resolve destinations across platforms.

Added `-destination 'generic/platform=iOS'` to the build, export and import invocations. It cannot resolve to macOS and doesn't depend on any particular simulator existing on the machine.

## Verification

On `dev`, with the Xcode 27.0 beta (`27A5237l`):

- `** BUILD SUCCEEDED **`, exit 0, **zero** `MACOSX_DEPLOYMENT_TARGET` mentions with the new destination flag
- All four scripts pass `zsh -n`
- The sourced `PROJECTS` list expands to the 18 correct entries

## What this does *not* fix

The report was `MACOSX_DEPLOYMENT_TARGET is set to 10.15` against five LoopKit targets under Xcode 27 beta 6. **I could not reproduce it** — `dev` builds clean on the Xcode 27.0 beta with the original destination-less command:

| Branch | Xcode 27.0 beta, no `-destination` |
|---|---|
| `dev` | `** BUILD SUCCEEDED **`, zero MACOSX errors |
| `next-dev` | `** BUILD SUCCEEDED **`, zero MACOSX errors |

`LoopKit.xcodeproj` has never set `MACOSX_DEPLOYMENT_TARGET` on any branch (`git log -S` confirms), and under Xcode 26 those targets resolve it to `26.5` from the SDK. `CGMBLEKit` and `LibreTransmitter` *do* hardcode `10.15`, and were present in both builds that succeeded — so that value alone isn't fatal to Xcode 27.

The destination flag is defensible hygiene and may sidestep the problem, but I have no evidence it is the cause. This PR should not be treated as closing that report. Narrowing it further would need the reporter's workspace commit, `git submodule status`, and exact `xcodebuild -version` build number to compare against `27A5237l`.

## Not addressed

`MixpanelService` and `LibreLoop` contain localizable resources but appear in no PROJECTS list. Adding them changes where translation PRs get opened, so that's left as a separate decision.

Supersedes #489, which made the same change against `next-dev`. `next-dev` still needs it eventually.